### PR TITLE
reorder logger messages for submit_elastic_package function

### DIFF
--- a/msc_pygeoapi/util.py
+++ b/msc_pygeoapi/util.py
@@ -123,13 +123,15 @@ def submit_elastic_package(es, package, request_size=10000):
                      .format(err.errors))
         return False
 
-    if len(errors) != 0:
-        LOGGER.error('Errors encountered in bulk insert: {}'.format(errors))
-        return False
-
     total = inserts + updates + noops
     LOGGER.info('Inserted package of {} observations ({} inserts, {} updates,'
                 ' {} no-ops'.format(total, inserts, updates, noops))
+
+    if len(errors) > 0:
+        LOGGER.warning('{} errors encountered in bulk insert: {}'.format(
+            len(errors), errors))
+        return False
+
     return True
 
 


### PR DESCRIPTION
Fixes an issue where when error was raised on insertion of document, `submit_elastic_package()` would return false and prevent the total insert, updates, no-ops message from being called by the logger.



