### PR TITLE
Cleanup Old Sarra Logs 

### DIFF
--- a/msc_pygeoapi/env.py
+++ b/msc_pygeoapi/env.py
@@ -44,6 +44,9 @@ MSC_PYGEOAPI_CACHEDIR = os.getenv('MSC_PYGEOAPI_CACHEDIR', '/tmp')
 MSC_PYGEOAPI_ES_USERNAME = os.getenv('MSC_PYGEOAPI_ES_USERNAME', None)
 MSC_PYGEOAPI_ES_PASSWORD = os.getenv('MSC_PYGEOAPI_ES_PASSWORD', None)
 
+SR_LOGGING_DIR = os.getenv('XDG_CACHE_DIR', None)
+
+
 if None in (MSC_PYGEOAPI_ES_USERNAME, MSC_PYGEOAPI_ES_PASSWORD):
     LOGGER.warning('Missing Elasticsearch authentication information:'
                    ' Continuing without authentication')

--- a/msc_pygeoapi/loader/hydrometric_realtime.py
+++ b/msc_pygeoapi/loader/hydrometric_realtime.py
@@ -36,7 +36,8 @@ import urllib.request
 from elasticsearch import helpers, logger as elastic_logger
 
 from msc_pygeoapi.env import (MSC_PYGEOAPI_CACHEDIR, MSC_PYGEOAPI_ES_TIMEOUT,
-                              MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH)
+                              MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH,
+                              SR_LOGGING_DIR)
 from msc_pygeoapi.loader.base import BaseLoader
 from msc_pygeoapi.util import click_abort_if_false, get_es
 
@@ -469,6 +470,15 @@ def clean_records(ctx, days):
     if len(response['failures']) > 0:
         click.echo('Failed to delete {} documents in time range'
                    .format(len(response['failures'])))
+
+    # Also delete old Sarracenia logs from before the cutoff date.
+    for filename in os.listdir(SR_LOGGING_DIR):
+        if not filename.endswith('.log'):
+            date_ = filename.split('.')[-1]
+
+            if date_ <= older_than:
+                fullpath = os.path.join(SR_LOGGING_DIR, filename)
+                os.remove(fullpath)
 
 
 @click.command()


### PR DESCRIPTION
Makes the `hydrometric_realtime clean-records` command delete old `sr_subscribe` logs in addition to deleting Elasticsearch documents.

`sr_subscribe` logs are assumed to be in the directory referred to be the `XDG_CACHE_DIR` environment variable, which is mandatory for hydrometric realtime to run and especially for the `clean-records` command.