### PR TITLE
add datetimeobj -> RFC3339-compliant string util function

### DIFF
--- a/msc_pygeoapi/loader/marine_weather_realtime.py
+++ b/msc_pygeoapi/loader/marine_weather_realtime.py
@@ -45,7 +45,7 @@ from msc_pygeoapi.env import (
     MSC_PYGEOAPI_ES_AUTH,
 )
 from msc_pygeoapi.loader.base import BaseLoader
-from msc_pygeoapi.util import get_es, json_pretty_print
+from msc_pygeoapi.util import get_es, json_pretty_print, strftime_rfc3339
 
 LOGGER = logging.getLogger(__name__)
 elastic_logger.setLevel(logging.WARNING)
@@ -415,7 +415,7 @@ class MarineWeatherRealtimeLoader(BaseLoader):
 
         try:
             result = self.ES.get(
-                index='forecast_polygons_water',
+                index='forecast_polygons_water_detail',
                 id=forecast_id,
                 _source=['geometry'],
             )
@@ -474,14 +474,10 @@ class MarineWeatherRealtimeLoader(BaseLoader):
                     'location_{}'.format(self.language): elem.attrib['name'],
                     'issued_datetime_utc_{}'.format(
                         self.language
-                    ): datetime.strftime(
-                        datetimes['utc'], '%Y-%m-%dT%H:%M:%SZ'
-                    ),
+                    ): strftime_rfc3339(datetimes['utc']),
                     'issued_datetime_local_{}'.format(
                         self.language
-                    ): datetime.strftime(
-                        datetimes['local'], '%Y-%m-%dT%H:%M:%S%z'
-                    ),
+                    ): strftime_rfc3339(datetimes['local']),
                     'event_type_{}'.format(self.language): elem.find(
                         'event'
                     ).attrib['type'],
@@ -543,11 +539,11 @@ class MarineWeatherRealtimeLoader(BaseLoader):
                     if element.tag == 'dateTime'
                 ]
             )
-            feature['properties']['issued_datetime_utc'] = datetime.strftime(
-                datetimes['utc'], '%Y-%m-%dT%H:%M:%SZ'
+            feature['properties']['issued_datetime_utc'] = strftime_rfc3339(
+                datetimes['utc']
             )
-            feature['properties']['issued_datetime_local'] = datetime.strftime(
-                datetimes['local'], '%Y-%m-%dT%H:%M:%S%z'
+            feature['properties']['issued_datetime_local'] = strftime_rfc3339(
+                datetimes['local']
             )
 
             locations = [
@@ -647,11 +643,11 @@ class MarineWeatherRealtimeLoader(BaseLoader):
                     if element.tag == 'dateTime'
                 ]
             )
-            feature['properties']['issued_datetime_utc'] = datetime.strftime(
-                datetimes['utc'], '%Y-%m-%dT%H:%M:%SZ'
+            feature['properties']['issued_datetime_utc'] = strftime_rfc3339(
+                datetimes['utc']
             )
-            feature['properties']['issued_datetime_local'] = datetime.strftime(
-                datetimes['local'], '%Y-%m-%dT%H:%M:%S%z'
+            feature['properties']['issued_datetime_local'] = strftime_rfc3339(
+                datetimes['local']
             )
 
             locations = [

--- a/msc_pygeoapi/util.py
+++ b/msc_pygeoapi/util.py
@@ -39,6 +39,8 @@ LOGGER = logging.getLogger(__name__)
 
 VERIFY = False
 
+DATETIME_RFC3339_FMT = '%Y-%m-%dT%H:%M:%SZ'
+
 
 def get_es(url, auth=None):
     """
@@ -212,3 +214,13 @@ def _get_element(node, path, attrib=None):
     if hasattr(val, 'text') and val.text not in [None, '']:
         return val.text
     return None
+
+
+def strftime_rfc3339(datetimeobj: datetime) -> str:
+    """
+    helper function to convert datetime object to RFC3393 compliant string.
+
+    :param datetimeobj: `datetime` object
+    :returns: RFC3339 compliant datetime `str`
+    """
+    return datetimeobj.strftime(DATETIME_RFC3339_FMT)


### PR DESCRIPTION
Adds a `strftime_rfc3339()` function to `util.py` in order to easily format a datetime object to an RFC3339-compliant string representation.

Also updates the `marine_weather_realtime` and `hurricanes_realtime` loaders to use this new helper function, and ensure proper format in their respective ES mappings.

