### PR TITLE
refactor common CLI options and older loaders

### DIFF
--- a/msc_pygeoapi/cli_options.py
+++ b/msc_pygeoapi/cli_options.py
@@ -1,0 +1,190 @@
+# =================================================================
+#
+# Author: Etienne Pelletier <etienne.pelletier@canada.ca>
+#
+# Copyright (c) 2020 Etienne Pelletier
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+import click
+
+from msc_pygeoapi.util import click_abort_if_false
+
+
+def OPTION_DATASET(*args, **kwargs):
+
+    default_args = ['--dataset']
+
+    default_kwargs = {
+        'required': True,
+        'help': 'ES dataset to load, or all if loading everything',
+    }
+
+    if not args:
+        args = default_args
+
+    kwargs = {**default_kwargs, **kwargs} if kwargs else default_kwargs
+
+    return click.option(*args, **kwargs)
+
+
+def OPTION_DAYS(**kwargs):
+
+    default_kwargs = {
+        'type': int,
+    }
+
+    kwargs = {**default_kwargs, **kwargs} if kwargs else default_kwargs
+
+    return click.option('--days', '-d', **kwargs)
+
+
+def OPTION_DB(*args, **kwargs):
+
+    default_args = ['--db']
+
+    default_kwargs = {
+        'required': True,
+        'help': 'Database connection string',
+    }
+
+    if not args:
+        args = default_args
+
+    kwargs = {**default_kwargs, **kwargs} if kwargs else default_kwargs
+
+    return click.option(*args, **kwargs)
+
+
+def OPTION_DIRECTORY(*args, **kwargs):
+
+    default_args = ['--directory', '-d', 'directory_']
+
+    default_kwargs = {
+        'type': click.Path(exists=True, resolve_path=True),
+        'required': False,
+        'help': 'Path to directory',
+    }
+
+    if not args:
+        args = default_args
+
+    kwargs = {**default_kwargs, **kwargs} if kwargs else default_kwargs
+
+    return click.option(*args, **kwargs)
+
+
+def OPTION_ELASTICSEARCH(*args, **kwargs):
+
+    default_args = ['--es']
+
+    default_kwargs = {
+        'help': 'URL to Elasticsearch',
+    }
+
+    if not args:
+        args = default_args
+
+    kwargs = {**default_kwargs, **kwargs} if kwargs else default_kwargs
+
+    return click.option(*args, **kwargs)
+
+
+def OPTION_ES_PASSWORD(*args, **kwargs):
+
+    default_args = ['--password']
+
+    default_kwargs = {
+        'help': 'Password to connect to Elasticsearch',
+    }
+
+    if not args:
+        args = default_args
+
+    kwargs = {**default_kwargs, **kwargs} if kwargs else default_kwargs
+
+    return click.option(*args, **kwargs)
+
+
+def OPTION_ES_USERNAME(*args, **kwargs):
+
+    default_args = ['--username']
+
+    default_kwargs = {
+        'help': 'Username to connect to Elasticsearch',
+    }
+
+    if not args:
+        args = default_args
+
+    kwargs = {**default_kwargs, **kwargs} if kwargs else default_kwargs
+
+    return click.option(*args, **kwargs)
+
+
+def OPTION_FILE(*args, **kwargs):
+
+    default_args = ['--file', '-f', 'file_']
+
+    default_kwargs = {
+        'type': click.Path(exists=True, resolve_path=True),
+        'required': False,
+        'help': 'Path to file',
+    }
+
+    if not args:
+        args = default_args
+
+    kwargs = {**default_kwargs, **kwargs} if kwargs else default_kwargs
+
+    return click.option(*args, **kwargs)
+
+
+def OPTION_INDEX_NAME(*args, **kwargs):
+
+    default_args = ['--index-name', '-i']
+
+    default_kwargs = {
+        'help': 'Elasticsearch index name to delete',
+    }
+
+    if not args:
+        args = default_args
+
+    kwargs = {**default_kwargs, **kwargs} if kwargs else default_kwargs
+
+    return click.option(*args, **kwargs)
+
+
+def OPTION_YES(**kwargs):
+
+    default_kwargs = {
+        'is_flag': True,
+        'callback': click_abort_if_false,
+        'expose_value': False,
+    }
+
+    kwargs = {**default_kwargs, **kwargs} if kwargs else default_kwargs
+
+    return click.option('--yes', **kwargs)

--- a/msc_pygeoapi/loader/ahccd.py
+++ b/msc_pygeoapi/loader/ahccd.py
@@ -1,3 +1,34 @@
+# =================================================================
+#
+# Author: Etienne Pelletier <etienne.pelletier@canada.ca>
+# Author: Alex Hurka <alex.hurka@canada.ca>
+#
+# Copyright (c) 2020 Etienne Pelletier
+# Copyright (c) 2019 Alex Hurka
+
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
 # Example Usage:
 # Load all datasets from scratch:
 # msc-pygeoapi data load ahccd --path /path/to/json/locations.json --es https://path/to/elasticsearch --username user --password pass --dataset all # noqa
@@ -9,7 +40,10 @@ import json
 import logging
 import click
 
-from msc_pygeoapi import util
+from msc_pygeoapi import cli_options
+from msc_pygeoapi.loader.base import BaseLoader
+from msc_pygeoapi.env import MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH
+from msc_pygeoapi.util import get_es, submit_elastic_package
 
 
 LOGGER = logging.getLogger(__name__)
@@ -20,706 +54,523 @@ HEADERS = {'Content-type': 'application/json'}
 VERIFY = False
 
 
-def create_index(es, index):
-    """
-    Creates the Elasticsearch index at es. If the index already exists,
-    it is deleted and re-created. The mappings for the two types are also
-    created.
+class AhccdLoader(BaseLoader):
+    """AHCCD Loader"""
 
-    :param es: elasticsearch.Elasticsearch object connected to ES cluster.
-    :param index: Identifier for the index to be created.
-    """
+    def __init__(self, plugin_def):
+        """initializer"""
 
-    if index == 'annual':
-        mapping =\
-            {
-                "settings": {
-                    "number_of_shards": 1,
-                    "number_of_replicas": 0
-                },
+        super().__init__()
+
+        if plugin_def['es_conn_dict']:
+            self.ES = get_es(
+                plugin_def['es_conn_dict']['host'],
+                plugin_def['es_conn_dict']['auth'],
+            )
+        else:
+            self.ES = get_es(MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH)
+
+    def create_index(self, index):
+        """
+        Creates the Elasticsearch index at self.ES. If the index already
+        exists, it is deleted and re-created. The mappings for the two types
+        are also created.
+
+        :param index: Identifier for the index to be created.
+        """
+
+        if index == 'annual':
+            mapping = {
+                "settings": {"number_of_shards": 1, "number_of_replicas": 0},
                 "mappings": {
-                    "_meta": {
-                        "geomfields": {
-                            "geometry": "POINT"
-                        }
-                    },
+                    "_meta": {"geomfields": {"geometry": "POINT"}},
                     "properties": {
                         "type": {"type": "text"},
                         "properties": {
                             "properties": {
                                 "identifier__identifiant": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "lat__lat": {
-                                    "type": "float"
-                                },
-                                "lon__long": {
-                                    "type": "float"
-                                },
+                                "lat__lat": {"type": "float"},
+                                "lon__long": {"type": "float"},
                                 "province__province": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "period_group__groupe_periode": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "period_value__valeur_periode": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "pressure_sea_level__pression_niveau_mer": {
                                     "type": "float"
                                 },
-                                "pressure_sea_level_units__pression_niveau_mer_unite": { # noqa
+                                "pressure_sea_level_units__pression_niveau_mer_unite": {  # noqa
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "pressure_station__pression_station": {
                                     "type": "float"
                                 },
-                                "pressure_station_units__pression_station_unites": { # noqa
+                                "pressure_station_units__pression_station_unites": {  # noqa
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "rain__pluie": {
-                                    "type": "float"
-                                },
+                                "rain__pluie": {"type": "float"},
                                 "rain_units__pluie_unites": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "snow__neige": {
-                                    "type": "float"
-                                },
+                                "snow__neige": {"type": "float"},
                                 "snow_units__neige_unites": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "station_id__id_station": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "temp_max__temp_max": {
-                                    "type": "float"
-                                },
+                                "temp_max__temp_max": {"type": "float"},
                                 "temp_max_units__temp_max_unites": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "temp_mean__temp_moyenne": {
-                                    "type": "float"
-                                },
+                                "temp_mean__temp_moyenne": {"type": "float"},
                                 "temp_mean_units__temp_moyenne_unites": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "temp_min__temp_min": {
-                                    "type": "float"
-                                },
+                                "temp_min__temp_min": {"type": "float"},
                                 "temp_min_units__temp_min_unites": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "total_precip__precip_totale": {
                                     "type": "float"
                                 },
                                 "total_precip_units__precip_totale_unites": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "wind_speed__vitesse_vent": {
-                                    "type": "float"
-                                },
+                                "wind_speed__vitesse_vent": {"type": "float"},
                                 "wind_speed_units__vitesse_vent_unites": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "year__annee": {
-                                    "type": "integer"
-                                }
+                                "year__annee": {"type": "integer"},
                             }
                         },
-                        "geometry": {"type": "geo_shape"}
-                    }
-                }
+                        "geometry": {"type": "geo_shape"},
+                    },
+                },
             }
 
-        index_name = 'ahccd_annual'
-        if es.indices.exists(index_name):
-            es.indices.delete(index_name)
-            LOGGER.info('Deleted the AHCCD annuals index')
-        es.indices.create(index=index_name, body=mapping)
+            index_name = 'ahccd_annual'
+            if self.ES.indices.exists(index_name):
+                self.ES.indices.delete(index_name)
+                LOGGER.info('Deleted the AHCCD annuals index')
+            self.ES.indices.create(index=index_name, body=mapping)
 
-    if index == 'monthly':
-        mapping =\
-            {
-                "settings": {
-                    "number_of_shards": 1,
-                    "number_of_replicas": 0
-                },
+        if index == 'monthly':
+            mapping = {
+                "settings": {"number_of_shards": 1, "number_of_replicas": 0},
                 "mappings": {
-                    "_meta": {
-                        "geomfields": {
-                            "geometry": "POINT"
-                        }
-                    },
+                    "_meta": {"geomfields": {"geometry": "POINT"}},
                     "properties": {
                         "type": {"type": "text"},
                         "properties": {
                             "properties": {
                                 "date": {
-                                   "type": "date",
-                                   "format": "yyyy-MM||yyyy"
+                                    "type": "date",
+                                    "format": "yyyy-MM||yyyy",
                                 },
                                 "identifier__identifiant": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "lat__lat": {
-                                    "type": "float"
-                                },
-                                "lon__long": {
-                                    "type": "float"
-                                },
+                                "lat__lat": {"type": "float"},
+                                "lon__long": {"type": "float"},
                                 "province__province": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "period_group__groupe_periode": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "period_value__valeur_periode": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "pressure_sea_level__pression_niveau_mer": {
                                     "type": "float"
                                 },
-                                "pressure_sea_level_units__pression_niveau_mer_unite": { # noqa
+                                "pressure_sea_level_units__pression_niveau_mer_unite": {  # noqa
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "pressure_station__pression_station": {
                                     "type": "float"
                                 },
-                                "pressure_station_units__pression_station_unites": { # noqa
+                                "pressure_station_units__pression_station_unites": {  # noqa
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "rain__pluie": {
-                                    "type": "float"
-                                },
+                                "rain__pluie": {"type": "float"},
                                 "rain_units__pluie_unites": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "snow__neige": {
-                                    "type": "float"
-                                },
+                                "snow__neige": {"type": "float"},
                                 "snow_units__neige_unites": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "station_id__id_station": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "temp_max__temp_max": {
-                                    "type": "float"
-                                },
+                                "temp_max__temp_max": {"type": "float"},
                                 "temp_max_units__temp_max_unites": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "temp_mean__temp_moyenne": {
-                                    "type": "float"
-                                },
+                                "temp_mean__temp_moyenne": {"type": "float"},
                                 "temp_mean_units__temp_moyenne_unites": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "temp_min__temp_min": {
-                                    "type": "float"
-                                },
+                                "temp_min__temp_min": {"type": "float"},
                                 "temp_min_units__temp_min_unites": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "total_precip__precip_totale": {
                                     "type": "float"
                                 },
                                 "total_precip_units__precip_totale_unites": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "wind_speed__vitesse_vent": {
-                                    "type": "float"
-                                },
+                                "wind_speed__vitesse_vent": {"type": "float"},
                                 "wind_speed_units__vitesse_vent_unites": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "year__annee": {
-                                    "type": "integer"
-                                }
+                                "year__annee": {"type": "integer"},
                             }
                         },
-                        "geometry": {"type": "geo_shape"}
-                    }
-                }
-            }
-
-        index_name = 'ahccd_monthly'
-        if es.indices.exists(index_name):
-            es.indices.delete(index_name)
-            LOGGER.info('Deleted the AHCCD monthlies index')
-        es.indices.create(index=index_name, body=mapping)
-
-    if index == 'seasonal':
-        mapping =\
-            {
-                "settings": {
-                    "number_of_shards": 1,
-                    "number_of_replicas": 0
-                },
-                "mappings": {
-                    "_meta": {
-                        "geomfields": {
-                            "geometry": "POINT"
-                        }
+                        "geometry": {"type": "geo_shape"},
                     },
-                    "properties": {
-                        "type": {"type": "text"},
-                        "properties": {
-                            "properties": {
-                                "identifier__identifiant": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "lat__lat": {
-                                    "type": "float"
-                                },
-                                "lon__long": {
-                                    "type": "float"
-                                },
-                                "province__province": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "period_group__groupe_periode": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "period_value__valeur_periode": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "pressure_sea_level__pression_niveau_mer": {
-                                    "type": "float"
-                                },
-                                "pressure_sea_level_units__pression_niveau_mer_unite": { # noqa
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "pressure_station__pression_station": {
-                                    "type": "float"
-                                },
-                                "pressure_station_units__pression_station_unites": { # noqa
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "rain__pluie": {
-                                    "type": "float"
-                                },
-                                "rain_units__pluie_unites": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "snow__neige": {
-                                    "type": "float"
-                                },
-                                "snow_units__neige_unites": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "station_id__id_station": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "temp_max__temp_max": {
-                                    "type": "float"
-                                },
-                                "temp_max_units__temp_max_unites": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "temp_mean__temp_moyenne": {
-                                    "type": "float"
-                                },
-                                "temp_mean_units__temp_moyenne_unites": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "temp_min__temp_min": {
-                                    "type": "float"
-                                },
-                                "temp_min_units__temp_min_unites": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "total_precip__precip_totale": {
-                                    "type": "float"
-                                },
-                                "total_precip_units__precip_totale_unites": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "wind_speed__vitesse_vent": {
-                                    "type": "float"
-                                },
-                                "wind_speed_units__vitesse_vent_unites": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "year__annee": {
-                                    "type": "integer"
-                                }
-                            }
-                        },
-                        "geometry": {"type": "geo_shape"}
-                    }
-                }
-            }
-
-        index_name = 'ahccd_seasonal'
-        if es.indices.exists(index_name):
-            es.indices.delete(index_name)
-            LOGGER.info('Deleted the AHCCD seasonals index')
-        es.indices.create(index=index_name, body=mapping)
-
-    if index == 'stations':
-        mapping =\
-            {
-                "settings": {
-                    "number_of_shards": 1,
-                    "number_of_replicas": 0
                 },
-                "mappings": {
-                    "_meta": {
-                        "geomfields": {
-                            "geometry": "POINT"
-                        }
-                    },
-                    "properties": {
-                        "type": {"type": "text"},
-                        "properties": {
-                            "properties": {
-                                "identifier__identifiant": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "station_id__id_station": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "station_name__nom_station": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "measurement_type__type_mesure": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "period__periode": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "trend_value__valeur_tendance": {
-                                    "type": "float"
-                                },
-                                "elevation__elevation": {
-                                    "type": "float"
-                                },
-                                "province__province": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "joined__rejoint": {
-                                    "type": "integer"
-                                },
-                                "year_range__annees": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                }
-                            }
-                        },
-                        "geometry": {"type": "geo_shape"}
-                    }
-                }
             }
 
-        index_name = 'ahccd_stations'
-        if es.indices.exists(index_name):
-            es.indices.delete(index_name)
-            LOGGER.info('Deleted the AHCCD stations index')
-        es.indices.create(index=index_name, body=mapping)
-
-    if index == 'trends':
-        mapping =\
-            {
-                "settings": {
-                    "number_of_shards": 1,
-                    "number_of_replicas": 0
-                },
-                "mappings": {
-                    "_meta": {
-                        "geomfields": {
-                            "geometry": "POINT"
-                        }
-                    },
-                    "properties": {
-                        "type": {"type": "text"},
-                        "properties": {
-                            "properties": {
-                                "identifier__identifiant": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "station_id__id_station": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "station_name__nom_station": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "measurement_type__type_mesure": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "period__periode": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "trend_value__valeur_tendance": {
-                                    "type": "float"
-                                },
-                                "elevation__elevation": {
-                                    "type": "float"
-                                },
-                                "province__province": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                },
-                                "joined__rejoint": {
-                                    "type": "integer"
-                                },
-                                "year_range__annees": {
-                                    "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                }
-                            }
-                        },
-                        "geometry": {"type": "geo_shape"}
-                    }
-                }
-            }
-
-        index_name = 'ahccd_trends'
-        if es.indices.exists(index_name):
-            es.indices.delete(index_name)
-            LOGGER.info('Deleted the AHCCD trends index')
-        es.indices.create(index=index_name, body=mapping)
-
-
-def generate_docs(fp, index):
-    """
-    Reads AHCCD and CMIP5 data from file(s) at fp and reformats them
-    so they can be nserted into Elasticsearch.
-
-    Returns a generator of dictionaries that represent upsert actions
-    into Elasticsearch's bulk API.
-
-    :param fp: the location of the raw data file(s) to load.
-    :param index: name of index to load.
-    :returns: generator of bulk API upsert actions.
-    """
-
-    if index not in ['stations', 'monthly', 'annual', 'seasonal', 'trends']:
-        LOGGER.error('Unrecognized AHCCD data type {}'.format(index))
-        return
-
-    try:
-        with open(fp, 'r') as f:
-            json_source = f.read()
-            contents = json.loads(json_source)
-    except Exception as err:
-        LOGGER.error('Could not open JSON file due to: {}.'
-                     .format(str(err)))
-        return
-
-    for record in contents['features']:
-        if index == 'annual':
-            index_name = 'ahccd_annual'
-        elif index == 'seasonal':
-            index_name = 'ahccd_seasonal'
-        elif index == 'stations':
-            index_name = 'ahccd_stations'
-            stn_id = record['properties']['station_id__id_station']
-            record['properties']['identifier__identifiant'] = stn_id
-        elif index == 'monthly':
             index_name = 'ahccd_monthly'
-            record['properties']['date'] = '{}-{}'.format(
-                record['properties']['identifier__identifiant'].split('.')[1],
-                record['properties']['identifier__identifiant'].split('.')[2])
-            del record['properties']['year__annee']
-        elif index == 'trends':
-            index_name = 'ahccd_trends'
-            identifier = '{}.{}.{}'.format(
-                record['properties']['station_id__id_station'],
-                record['properties']['period__periode'],
-                record['properties']['measurement_type__type_mesure'])
-            record['properties']['identifier__identifiant'] = identifier
+            if self.ES.indices.exists(index_name):
+                self.ES.indices.delete(index_name)
+                LOGGER.info('Deleted the AHCCD monthlies index')
+            self.ES.indices.create(index=index_name, body=mapping)
 
-        action = {
-            '_id': record['properties']['identifier__identifiant'],
-            '_index': index_name,
-            '_op_type': 'update',
-            'doc': record,
-            'doc_as_upsert': True
-        }
-        yield action
+        if index == 'seasonal':
+            mapping = {
+                "settings": {"number_of_shards": 1, "number_of_replicas": 0},
+                "mappings": {
+                    "_meta": {"geomfields": {"geometry": "POINT"}},
+                    "properties": {
+                        "type": {"type": "text"},
+                        "properties": {
+                            "properties": {
+                                "identifier__identifiant": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "lat__lat": {"type": "float"},
+                                "lon__long": {"type": "float"},
+                                "province__province": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "period_group__groupe_periode": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "period_value__valeur_periode": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "pressure_sea_level__pression_niveau_mer": {
+                                    "type": "float"
+                                },
+                                "pressure_sea_level_units__pression_niveau_mer_unite": {  # noqa
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "pressure_station__pression_station": {
+                                    "type": "float"
+                                },
+                                "pressure_station_units__pression_station_unites": {  # noqa
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "rain__pluie": {"type": "float"},
+                                "rain_units__pluie_unites": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "snow__neige": {"type": "float"},
+                                "snow_units__neige_unites": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "station_id__id_station": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "temp_max__temp_max": {"type": "float"},
+                                "temp_max_units__temp_max_unites": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "temp_mean__temp_moyenne": {"type": "float"},
+                                "temp_mean_units__temp_moyenne_unites": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "temp_min__temp_min": {"type": "float"},
+                                "temp_min_units__temp_min_unites": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "total_precip__precip_totale": {
+                                    "type": "float"
+                                },
+                                "total_precip_units__precip_totale_unites": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "wind_speed__vitesse_vent": {"type": "float"},
+                                "wind_speed_units__vitesse_vent_unites": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "year__annee": {"type": "integer"},
+                            }
+                        },
+                        "geometry": {"type": "geo_shape"},
+                    },
+                },
+            }
+
+            index_name = 'ahccd_seasonal'
+            if self.ES.indices.exists(index_name):
+                self.ES.indices.delete(index_name)
+                LOGGER.info('Deleted the AHCCD seasonals index')
+            self.ES.indices.create(index=index_name, body=mapping)
+
+        if index == 'stations':
+            mapping = {
+                "settings": {"number_of_shards": 1, "number_of_replicas": 0},
+                "mappings": {
+                    "_meta": {"geomfields": {"geometry": "POINT"}},
+                    "properties": {
+                        "type": {"type": "text"},
+                        "properties": {
+                            "properties": {
+                                "identifier__identifiant": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "station_id__id_station": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "station_name__nom_station": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "measurement_type__type_mesure": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "period__periode": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "trend_value__valeur_tendance": {
+                                    "type": "float"
+                                },
+                                "elevation__elevation": {"type": "float"},
+                                "province__province": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "joined__rejoint": {"type": "integer"},
+                                "year_range__annees": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                            }
+                        },
+                        "geometry": {"type": "geo_shape"},
+                    },
+                },
+            }
+
+            index_name = 'ahccd_stations'
+            if self.ES.indices.exists(index_name):
+                self.ES.indices.delete(index_name)
+                LOGGER.info('Deleted the AHCCD stations index')
+            self.ES.indices.create(index=index_name, body=mapping)
+
+        if index == 'trends':
+            mapping = {
+                "settings": {"number_of_shards": 1, "number_of_replicas": 0},
+                "mappings": {
+                    "_meta": {"geomfields": {"geometry": "POINT"}},
+                    "properties": {
+                        "type": {"type": "text"},
+                        "properties": {
+                            "properties": {
+                                "identifier__identifiant": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "station_id__id_station": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "station_name__nom_station": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "measurement_type__type_mesure": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "period__periode": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "trend_value__valeur_tendance": {
+                                    "type": "float"
+                                },
+                                "elevation__elevation": {"type": "float"},
+                                "province__province": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                                "joined__rejoint": {"type": "integer"},
+                                "year_range__annees": {
+                                    "type": "text",
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
+                            }
+                        },
+                        "geometry": {"type": "geo_shape"},
+                    },
+                },
+            }
+
+            index_name = 'ahccd_trends'
+            if self.ES.indices.exists(index_name):
+                self.ES.indices.delete(index_name)
+                LOGGER.info('Deleted the AHCCD trends index')
+            self.ES.indices.create(index=index_name, body=mapping)
+
+    def generate_docs(self, fp, index):
+        """
+        Reads AHCCD and CMIP5 data from file(s) at fp and reformats them
+        so they can be nserted into Elasticsearch.
+
+        Returns a generator of dictionaries that represent upsert actions
+        into Elasticsearch's bulk API.
+
+        :param fp: the location of the raw data file(s) to load.
+        :param index: name of index to load.
+        :returns: generator of bulk API upsert actions.
+        """
+
+        if index not in [
+            'stations',
+            'monthly',
+            'annual',
+            'seasonal',
+            'trends',
+        ]:
+            LOGGER.error('Unrecognized AHCCD data type {}'.format(index))
+            return
+
+        try:
+            with open(fp, 'r') as f:
+                json_source = f.read()
+                contents = json.loads(json_source)
+        except Exception as err:
+            LOGGER.error(f'Could not open JSON file due to: {str(err)}.')
+            return
+
+        for record in contents['features']:
+            if index == 'annual':
+                index_name = 'ahccd_annual'
+            elif index == 'seasonal':
+                index_name = 'ahccd_seasonal'
+            elif index == 'stations':
+                index_name = 'ahccd_stations'
+                stn_id = record['properties']['station_id__id_station']
+                record['properties']['identifier__identifiant'] = stn_id
+            elif index == 'monthly':
+                index_name = 'ahccd_monthly'
+                record['properties']['date'] = '{}-{}'.format(
+                    record['properties']['identifier__identifiant'].split('.')[
+                        1
+                    ],
+                    record['properties']['identifier__identifiant'].split('.')[
+                        2
+                    ],
+                )
+                del record['properties']['year__annee']
+            elif index == 'trends':
+                index_name = 'ahccd_trends'
+                identifier = '{}.{}.{}'.format(
+                    record['properties']['station_id__id_station'],
+                    record['properties']['period__periode'],
+                    record['properties']['measurement_type__type_mesure'],
+                )
+                record['properties']['identifier__identifiant'] = identifier
+
+            action = {
+                '_id': record['properties']['identifier__identifiant'],
+                '_index': index_name,
+                '_op_type': 'update',
+                'doc': record,
+                'doc_as_upsert': True,
+            }
+            yield action
+
+
+@click.group()
+def ahccd():
+    """Manages AHCCD indices"""
+    pass
 
 
 @click.command()
 @click.pass_context
-@click.option('--path', type=click.Path(exists=True, resolve_path=True),
-              help='Path to file with raw JSON locations')
-@click.option('--es', help='URL to Elasticsearch.')
-@click.option('--username', help='Username to connect to HTTPS')
-@click.option('--password', help='Password to connect to HTTPS')
-@click.option('--dataset', help='ES dataset to load, or all\
-                                 if loading everything')
-def ahccd(ctx, path, es, username, password, dataset):
+@cli_options.OPTION_FILE('--path', help='Path to file with raw JSON')
+@cli_options.OPTION_ELASTICSEARCH()
+@cli_options.OPTION_ES_USERNAME()
+@cli_options.OPTION_ES_PASSWORD()
+@cli_options.OPTION_DATASET(
+    type=click.Choice(
+        ['all', 'stations', 'trends', 'annual', 'seasonal', 'monthly']
+    )
+)
+def add(ctx, path, es, username, password, dataset):
     """
-    Loads AHCCD and CMIP5 data into Elasticsearch
-
-    Controls transformation from oracle to Elasticsearch.
+    Loads AHCCD data from Oracle into Elasticsearch.
 
     The JSON locations file should be a JSON of the form:
     {
@@ -737,133 +588,137 @@ def ahccd(ctx, path, es, username, password, dataset):
     :param dataset: name of dataset to load, or all for all datasets.
     """
 
-    auth = (username, password)
-    es_client = util.get_es(es, auth)
+    plugin_def = {
+        'es_conn_dict': {'host': es, 'auth': (username, password)}
+        if all([es, username, password])
+        else None,
+        'handler': 'msc_pygeoapi.loader.ahccd.AhccdLoader',
+    }
+
+    loader = AhccdLoader(plugin_def)
 
     try:
         with open(path, 'r') as f:
             path_dict = json.loads(f.read())
     except Exception as err:
-        LOGGER.error('Could not open JSON location file due to: {}.'
-                     .format(str(err)))
+        LOGGER.error(
+            f'Could not open JSON location file due to: {str(err)}.'.format(
+                str(err)
+            )
+        )
 
     if dataset == 'all':
         try:
             LOGGER.info('Populating stations...')
-            create_index(es_client, 'stations')
-            stations = generate_docs(path_dict['stations'], 'stations')
+            loader.create_index('stations')
+            stations = loader.generate_docs(path_dict['stations'], 'stations')
 
-            util.submit_elastic_package(es_client, stations)
+            submit_elastic_package(loader.ES, stations)
             LOGGER.info('Stations populated.')
         except Exception as err:
-            LOGGER.error('Could not populate stations due to: {}.'
-                         .format(str(err)))
+            LOGGER.error(f'Could not populate stations due to: {str(err)}.')
 
         try:
             LOGGER.info('Populating trends...')
-            create_index(es_client, 'trends')
-            trends = generate_docs(path_dict['trends'], 'trends')
+            loader.create_index('trends')
+            trends = loader.generate_docs(path_dict['trends'], 'trends')
 
-            util.submit_elastic_package(es_client, trends)
+            submit_elastic_package(loader.ES, trends)
             LOGGER.info('Trends populated.')
         except Exception as err:
-            LOGGER.error('Could not populate trends due to: {}.'
-                         .format(str(err)))
+            LOGGER.error(f'Could not populate trends due to: {str(err)}.')
 
         try:
             LOGGER.info('Populating annual...')
-            create_index(es_client, 'annual')
-            annuals = generate_docs(path_dict['annual'], 'annual')
+            loader.create_index('annual')
+            annuals = loader.generate_docs(path_dict['annual'], 'annual')
 
-            util.submit_elastic_package(es_client, annuals)
+            submit_elastic_package(loader.ES, annuals)
             LOGGER.info('Annual populated.')
         except Exception as err:
-            LOGGER.error('Could not populate annual due to: {}.'
-                         .format(str(err)))
+            LOGGER.error(f'Could not populate annual due to: {str(err)}.')
 
         try:
             LOGGER.info('Populating seasonal...')
-            create_index(es_client, 'seasonal')
-            seasonals = generate_docs(path_dict['seasonal'], 'seasonal')
+            loader.create_index('seasonal')
+            seasonals = loader.generate_docs(path_dict['seasonal'], 'seasonal')
 
-            util.submit_elastic_package(es_client, seasonals)
+            submit_elastic_package(loader.ES, seasonals)
             LOGGER.info('Seasonal populated.')
         except Exception as err:
-            LOGGER.error('Could not populate seasonal due to: {}.'
-                         .format(str(err)))
+            LOGGER.error(f'Could not populate seasonal due to: {str(err)}.')
 
         try:
             LOGGER.info('Populating monthly...')
-            create_index(es_client, 'monthly')
-            monthlies = generate_docs(path_dict['monthly'], 'monthly')
+            loader.create_index('monthly')
+            monthlies = loader.generate_docs(path_dict['monthly'], 'monthly')
 
-            util.submit_elastic_package(es_client, monthlies)
+            submit_elastic_package(loader.ES, monthlies)
             LOGGER.info('Monthly populated.')
         except Exception as err:
-            LOGGER.error('Could not populate monthly due to: {}.'
-                         .format(str(err)))
+            LOGGER.error(f'Could not populate monthly due to: {str(err)}.')
 
     elif dataset == 'stations':
         try:
             LOGGER.info('Populating stations...')
-            create_index(es_client, 'stations')
-            stations = generate_docs(path_dict['stations'], 'stations')
+            loader.create_index('stations')
+            stations = loader.generate_docs(path_dict['stations'], 'stations')
 
-            util.submit_elastic_package(es_client, stations)
+            submit_elastic_package(loader.ES, stations)
             LOGGER.info('Stations populated.')
         except Exception as err:
-            LOGGER.error('Could not populate stations due to: {}.'
-                         .format(str(err)))
+            LOGGER.error(f'Could not populate stations due to: {str(err)}.')
 
     elif dataset == 'trends':
         try:
             LOGGER.info('Populating trends...')
-            create_index(es_client, 'trends')
-            trends = generate_docs(path_dict['trends'], 'trends')
+            loader.create_index('trends')
+            trends = loader.generate_docs(path_dict['trends'], 'trends')
 
-            util.submit_elastic_package(es_client, trends)
+            submit_elastic_package(loader.ES, trends)
             LOGGER.info('Trends populated.')
         except Exception as err:
-            LOGGER.error('Could not populate trends due to: {}.'
-                         .format(str(err)))
+            LOGGER.error(f'Could not populate trends due to: {str(err)}.')
 
     elif dataset == 'annual':
         try:
             LOGGER.info('Populating annual...')
-            create_index(es_client, 'annual')
-            annuals = generate_docs(path_dict['annual'], 'annual')
+            loader.create_index('annual')
+            annuals = loader.generate_docs(path_dict['annual'], 'annual')
 
-            util.submit_elastic_package(es_client, annuals)
+            submit_elastic_package(loader.ES, annuals)
             LOGGER.info('Annual populated.')
         except Exception as err:
-            LOGGER.error('Could not populate annual due to: {}.'
-                         .format(str(err)))
+            LOGGER.error(f'Could not populate annual due to: {str(err)}.')
 
     elif dataset == 'seasonal':
         try:
             LOGGER.info('Populating seasonal...')
-            create_index(es_client, 'seasonal')
-            seasonals = generate_docs(path_dict['seasonal'], 'seasonal')
+            loader.create_index('seasonal')
+            seasonals = loader.generate_docs(path_dict['seasonal'], 'seasonal')
 
-            util.submit_elastic_package(es_client, seasonals)
+            submit_elastic_package(loader.ES, seasonals)
             LOGGER.info('Seasonal populated.')
         except Exception as err:
-            LOGGER.error('Could not populate seasonal due to: {}.'
-                         .format(str(err)))
+            LOGGER.error(f'Could not populate seasonal due to: {str(err)}.')
 
     elif dataset == 'monthly':
         try:
             LOGGER.info('Populating monthly...')
-            create_index(es_client, 'monthly')
-            monthlies = generate_docs(path_dict['monthly'], 'monthly')
+            loader.create_index('monthly')
+            monthlies = loader.generate_docs(path_dict['monthly'], 'monthly')
 
-            util.submit_elastic_package(es_client, monthlies)
+            submit_elastic_package(loader.ES, monthlies)
             LOGGER.info('Monthly populated.')
         except Exception as err:
-            LOGGER.error('Could not populate monthly due to: {}.'
-                         .format(str(err)))
+            LOGGER.error(f'Could not populate monthly due to: {str(err)}.')
 
     else:
-        LOGGER.critical('Unknown dataset parameter {}, skipping index population.'.format(dataset)) # noqa
+        LOGGER.critical(
+            f'Unknown dataset parameter {dataset}, skipping index population.'
+        )
 
     LOGGER.info('Finished populating indices.')
+
+
+ahccd.add_command(add)

--- a/msc_pygeoapi/loader/bulletins.py
+++ b/msc_pygeoapi/loader/bulletins.py
@@ -31,10 +31,11 @@ import click
 from datetime import datetime, timedelta
 import logging
 
+from msc_pygeoapi import cli_options
 from msc_pygeoapi.env import (MSC_PYGEOAPI_ES_TIMEOUT, MSC_PYGEOAPI_ES_URL,
                               MSC_PYGEOAPI_ES_AUTH)
 from msc_pygeoapi.loader.base import BaseLoader
-from msc_pygeoapi.util import click_abort_if_false, get_es
+from msc_pygeoapi.util import get_es
 
 
 LOGGER = logging.getLogger(__name__)
@@ -172,12 +173,13 @@ def bulletins():
 
 @click.command()
 @click.pass_context
-@click.option('--days', '-d', default=DAYS_TO_KEEP, type=int,
-              help='delete documents older than n days (default={})'.format(
-                  DAYS_TO_KEEP))
-@click.option('--yes', is_flag=True, callback=click_abort_if_false,
-              expose_value=False,
-              prompt='Are you sure you want to delete old documents?')
+@cli_options.OPTION_DAYS(
+    default=DAYS_TO_KEEP,
+    help=f'Delete documents older than n days (default={DAYS_TO_KEEP})'
+)
+@cli_options.OPTION_YES(
+    prompt='Are you sure you want to delete old documents?'
+)
 def clean_records(ctx, days):
     """Delete old documents"""
 
@@ -203,9 +205,9 @@ def clean_records(ctx, days):
 
 @click.command()
 @click.pass_context
-@click.option('--yes', is_flag=True, callback=click_abort_if_false,
-              expose_value=False,
-              prompt='Are you sure you want to delete this index?')
+@cli_options.OPTION_YES(
+    prompt='Are you sure you want to delete this index?'
+)
 def delete_index(ctx):
     """Delete bulletins index"""
 

--- a/msc_pygeoapi/loader/cap_alerts_realtime.py
+++ b/msc_pygeoapi/loader/cap_alerts_realtime.py
@@ -35,11 +35,11 @@ from lxml import etree
 import os
 import re
 
+from msc_pygeoapi import cli_options
 from msc_pygeoapi.env import (MSC_PYGEOAPI_ES_TIMEOUT, MSC_PYGEOAPI_ES_URL,
                               MSC_PYGEOAPI_ES_AUTH)
 from msc_pygeoapi.loader.base import BaseLoader
-from msc_pygeoapi.util import (click_abort_if_false, get_es,
-                               json_pretty_print, _get_date_format,
+from msc_pygeoapi.util import (get_es, json_pretty_print, _get_date_format,
                                _get_element)
 
 LOGGER = logging.getLogger(__name__)
@@ -460,13 +460,8 @@ def cap_alerts():
 
 @click.command()
 @click.pass_context
-@click.option('--file', '-f', 'file_',
-              type=click.Path(exists=True, resolve_path=True),
-              help='Path to file')
-@click.option('--directory', '-d', 'directory',
-              type=click.Path(exists=True, resolve_path=True,
-                              dir_okay=True, file_okay=False),
-              help='Path to directory')
+@cli_options.OPTION_FILE()
+@cli_options.OPTION_DIRECTORY()
 def add(ctx, file_, directory):
     """add data to system"""
 
@@ -497,12 +492,13 @@ def add(ctx, file_, directory):
 
 @click.command()
 @click.pass_context
-@click.option('--days', '-d', default=DAYS_TO_KEEP, type=int,
-              help='delete documents older than n days (default={})'.format(
-                  DAYS_TO_KEEP))
-@click.option('--yes', is_flag=True, callback=click_abort_if_false,
-              expose_value=False,
-              prompt='Are you sure you want to delete old documents?')
+@cli_options.OPTION_DAYS(
+    default=DAYS_TO_KEEP,
+    help=f'Delete documents older than n days (default={DAYS_TO_KEEP})'
+)
+@cli_options.OPTION_YES(
+    prompt='Are you sure you want to delete old documents?'
+)
 def clean_records(ctx, days):
     """Delete old documents"""
 
@@ -528,9 +524,9 @@ def clean_records(ctx, days):
 
 @click.command()
 @click.pass_context
-@click.option('--yes', is_flag=True, callback=click_abort_if_false,
-              expose_value=False,
-              prompt='Are you sure you want to delete this index?')
+@cli_options.OPTION_YES(
+    prompt='Are you sure you want to delete this index?'
+)
 def delete_index(ctx):
     """Delete current conditions index"""
 

--- a/msc_pygeoapi/loader/citypageweather_realtime.py
+++ b/msc_pygeoapi/loader/citypageweather_realtime.py
@@ -35,10 +35,11 @@ import logging
 from lxml import etree
 import os
 
+from msc_pygeoapi import cli_options
 from msc_pygeoapi.env import (MSC_PYGEOAPI_ES_TIMEOUT, MSC_PYGEOAPI_ES_URL,
                               MSC_PYGEOAPI_ES_AUTH, MSC_PYGEOAPI_BASEPATH)
 from msc_pygeoapi.loader.base import BaseLoader
-from msc_pygeoapi.util import click_abort_if_false, get_es
+from msc_pygeoapi.util import get_es
 
 LOGGER = logging.getLogger(__name__)
 
@@ -494,12 +495,13 @@ def citypageweather():
 
 @click.command()
 @click.pass_context
-@click.option('--days', '-d', default=DAYS_TO_KEEP, type=int,
-              help='delete documents older than n days (default={})'.format(
-                  DAYS_TO_KEEP))
-@click.option('--yes', is_flag=True, callback=click_abort_if_false,
-              expose_value=False,
-              prompt='Are you sure you want to delete old documents?')
+@cli_options.OPTION_DAYS(
+    default=DAYS_TO_KEEP,
+    help=f'Delete documents older than n days (default={DAYS_TO_KEEP})'
+)
+@cli_options.OPTION_YES(
+    prompt='Are you sure you want to delete old documents?'
+)
 def clean_records(ctx, days):
     """Delete old documents"""
 
@@ -525,9 +527,9 @@ def clean_records(ctx, days):
 
 @click.command()
 @click.pass_context
-@click.option('--yes', is_flag=True, callback=click_abort_if_false,
-              expose_value=False,
-              prompt='Are you sure you want to delete this index?')
+@cli_options.OPTION_YES(
+    prompt='Are you sure you want to delete this index?'
+)
 def delete_index(ctx):
     """Delete current conditions index"""
 

--- a/msc_pygeoapi/loader/climate_archive.py
+++ b/msc_pygeoapi/loader/climate_archive.py
@@ -1,3 +1,34 @@
+# =================================================================
+#
+# Author: Etienne Pelletier <etienne.pelletier@canada.ca>
+# Author: Alex Hurka <alex.hurka@canada.ca>
+#
+# Copyright (c) 2020 Etienne Pelletier
+# Copyright (c) 2019 Alex Hurka
+
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
 # Example Usage:
 # Load all datasets from scratch:
 # python es_loader_msc_climate_archive.py --db <oracle db connection string> --es https://path/to/elasticsearch --username user --password pass --dataset all # noqa
@@ -17,7 +48,10 @@ import cx_Oracle
 import click
 import collections
 
-from msc_pygeoapi import util
+from msc_pygeoapi import cli_options
+from msc_pygeoapi.loader.base import BaseLoader
+from msc_pygeoapi.env import MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH
+from msc_pygeoapi.util import get_es, submit_elastic_package
 
 
 logging.basicConfig()
@@ -29,288 +63,217 @@ HEADERS = {'Content-type': 'application/json'}
 VERIFY = False
 
 
-def create_index(es, index):
-    """
-    Creates the Elasticsearch index at path. If the index already exists,
-    it is deleted and re-created. The mappings for the two types are also
-    created.
+class ClimateArchiveLoader(BaseLoader):
+    """Climat Archive Loader"""
 
-    :param path: the path to Elasticsearch.
-    :param index: the index to be created.
-    :param AUTH: tuple of username and password used to authorize the
-                 HTTP request.
-    """
+    def __init__(self, plugin_def):
+        """initializer"""
 
-    if index == 'stations':
-        mapping =\
-            {
-                "settings": {
-                    "number_of_shards": 1,
-                    "number_of_replicas": 0
-                },
+        super().__init__()
+
+        if plugin_def['es_conn_dict']:
+            self.ES = get_es(
+                plugin_def['es_conn_dict']['host'],
+                plugin_def['es_conn_dict']['auth'],
+            )
+        else:
+            self.ES = get_es(MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH)
+
+        # setup DB connection
+        try:
+            self.con = cx_Oracle.connect(plugin_def['db_conn_string'])
+        except Exception as err:
+            msg = f'Could not connect to Oracle: {err}'
+            LOGGER.critical(msg)
+            raise click.ClickException(msg)
+
+        self.cur = self.con.cursor()
+
+    def create_index(self, index):
+        """
+        Creates the Elasticsearch index at path. If the index already exists,
+        it is deleted and re-created. The mappings for the two types are also
+        created.
+
+        :param index: the index to be created.
+        """
+
+        if index == 'stations':
+            mapping = {
+                "settings": {"number_of_shards": 1, "number_of_replicas": 0},
                 "mappings": {
-                    "_meta": {
-                        "geomfields": {
-                            "geometry": "POINT"
-                        }
-                    },
+                    "_meta": {"geomfields": {"geometry": "POINT"}},
                     "properties": {
                         "type": {"type": "text"},
                         "properties": {
                             "properties": {
                                 "PROV_STATE_TERR_CODE": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "STN_ID": {
-                                    "type": "integer"
-                                },
+                                "STN_ID": {"type": "integer"},
                                 "STATION_NAME": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "ENG_PROV_NAME": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "FRE_PROV_NAME": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "COUNTRY": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "LATITUDE": {
-                                    "type": "integer"
-                                },
-                                "LONGITUDE": {
-                                    "type": "integer"
-                                },
+                                "LATITUDE": {"type": "integer"},
+                                "LONGITUDE": {"type": "integer"},
                                 "TIMEZONE": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "ELEVATION": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "CLIMATE_IDENTIFIER": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "TC_IDENTIFIER": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "WMO_IDENTIFIER": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "STATION_TYPE": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "NORMAL_CODE": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "PUBLICATION_CODE": {
-                                    "type": "integer"
-                                },
-                                "DISPLAY_CODE": {
-                                    "type": "integer"
-                                },
+                                "PUBLICATION_CODE": {"type": "integer"},
+                                "DISPLAY_CODE": {"type": "integer"},
                                 "ENG_STN_OPERATOR_ACRONYM": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "FRE_STN_OPERATOR_ACRONYM": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "ENG_STN_OPERATOR_NAME": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "FRE_STN_OPERATOR_NAME": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "HAS_MONTHLY_SUMMARY": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "HAS_NORMALS_DATA": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "DLY_FIRST_DATE": {
                                     "type": "date",
-                                    "format": "yyyy-MM-dd HH:mm:ss"
+                                    "format": "yyyy-MM-dd HH:mm:ss",
                                 },
                                 "DLY_LAST_DATE": {
                                     "type": "date",
-                                    "format": "yyyy-MM-dd HH:mm:ss"
+                                    "format": "yyyy-MM-dd HH:mm:ss",
                                 },
                                 "FIRST_DATE": {
                                     "type": "date",
-                                    "format": "yyyy-MM-dd HH:mm:ss"
+                                    "format": "yyyy-MM-dd HH:mm:ss",
                                 },
                                 "LAST_DATE": {
                                     "type": "date",
-                                    "format": "yyyy-MM-dd HH:mm:ss"
-                                }
+                                    "format": "yyyy-MM-dd HH:mm:ss",
+                                },
                             }
                         },
-                        "geometry": {"type": "geo_shape"}
-                    }
-                }
+                        "geometry": {"type": "geo_shape"},
+                    },
+                },
             }
 
-        index_name = 'climate_station_information'
+            index_name = 'climate_station_information'
 
-        if es.indices.exists(index_name):
-            es.indices.delete(index_name)
-            LOGGER.info('Deleted the stations index')
-        es.indices.create(index=index_name, body=mapping)
+            if self.ES.indices.exists(index_name):
+                self.ES.indices.delete(index_name)
+                LOGGER.info('Deleted the stations index')
+            self.ES.indices.create(index=index_name, body=mapping)
 
-    if index == 'normals':
-        mapping =\
-            {
-                "settings": {
-                    "number_of_shards": 1,
-                    "number_of_replicas": 0
-                },
+        if index == 'normals':
+            mapping = {
+                "settings": {"number_of_shards": 1, "number_of_replicas": 0},
                 "mappings": {
-                    "_meta": {
-                        "geomfields": {
-                            "geometry": "POINT"
-                        }
-                    },
+                    "_meta": {"geomfields": {"geometry": "POINT"}},
                     "properties": {
                         "type": {"type": "text"},
                         "properties": {
                             "properties": {
                                 "STN_ID": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "MONTH": {
-                                    "type": "integer"
-                                },
-                                "VALUE": {
-                                    "type": "integer"
-                                },
-                                "OCCURRENCE_COUNT": {
-                                    "type": "integer"
-                                },
-                                "PUBLICATION_CODE": {
-                                    "type": "integer"
-                                },
+                                "MONTH": {"type": "integer"},
+                                "VALUE": {"type": "integer"},
+                                "OCCURRENCE_COUNT": {"type": "integer"},
+                                "PUBLICATION_CODE": {"type": "integer"},
                                 "CLIMATE_IDENTIFIER": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "NORMAL_CODE": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "NORMAL_ID": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "ID": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "PROVINCE_CODE": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "E_NORMAL_ELEMENT_NAME": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "F_NORMAL_ELEMENT_NAME": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "PERIOD": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "PERIOD_BEGIN": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "PERIOD_END": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "STATION_NAME": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "YEAR_COUNT_NORMAL_PERIOD": {
                                     "type": "integer"
@@ -321,141 +284,85 @@ def create_index(es, index):
                                 "FIRST_YEAR_NORMAL_PERIOD": {
                                     "type": "integer"
                                 },
-                                "LAST_YEAR_NORMAL_PERIOD": {
-                                    "type": "integer"
-                                },
-                                "FIRST_YEAR": {
-                                    "type": "integer"
-                                },
-                                "LAST_YEAR": {
-                                    "type": "integer"
-                                },
-                                "TOTAL_OBS_COUNT": {
-                                    "type": "integer"
-                                },
-                                "PERCENT_OF_POSSIBLE_OBS": {
-                                    "type": "integer"
-                                },
+                                "LAST_YEAR_NORMAL_PERIOD": {"type": "integer"},
+                                "FIRST_YEAR": {"type": "integer"},
+                                "LAST_YEAR": {"type": "integer"},
+                                "TOTAL_OBS_COUNT": {"type": "integer"},
+                                "PERCENT_OF_POSSIBLE_OBS": {"type": "integer"},
                                 "CURRENT_FLAG": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "FIRST_OCCURRENCE_DATE": {
                                     "type": "date",
-                                    "format": "yyyy-MM-dd HH:mm:ss"
+                                    "format": "yyyy-MM-dd HH:mm:ss",
                                 },
                                 "DATE_CALCULATED": {
                                     "type": "date",
-                                    "format": "yyyy-MM-dd HH:mm:ss"
-                                }
+                                    "format": "yyyy-MM-dd HH:mm:ss",
+                                },
                             }
                         },
-                        "geometry": {"type": "geo_shape"}
-                    }
-                }
+                        "geometry": {"type": "geo_shape"},
+                    },
+                },
             }
 
-        index_name = 'climate_normals_data'
+            index_name = 'climate_normals_data'
 
-        if es.indices.exists(index_name):
-            es.indices.delete(index_name)
-            LOGGER.info('Deleted the climate normals index')
-        es.indices.create(index=index_name, body=mapping)
+            if self.ES.indices.exists(index_name):
+                self.ES.indices.delete(index_name)
+                LOGGER.info('Deleted the climate normals index')
+            self.ES.indices.create(index=index_name, body=mapping)
 
-    if index == 'monthly_summary':
-        mapping =\
-            {
-                "settings": {
-                    "number_of_shards": 1,
-                    "number_of_replicas": 0
-                },
+        if index == 'monthly_summary':
+            mapping = {
+                "settings": {"number_of_shards": 1, "number_of_replicas": 0},
                 "mappings": {
-                    "_meta": {
-                        "geomfields": {
-                            "geometry": "POINT"
-                        }
-                    },
+                    "_meta": {"geomfields": {"geometry": "POINT"}},
                     "properties": {
                         "type": {"type": "text"},
                         "properties": {
                             "properties": {
                                 "CLIMATE_IDENTIFIER": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "STN_ID": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "STATION_NAME": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "ID": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "PROVINCE_CODE": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "LATITUDE": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "LONGITUDE": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "MEAN_TEMPERATURE": {
-                                    "type": "float"
-                                },
-                                "NORMAL_MEAN_TEMPERATURE": {
-                                    "type": "float"
-                                },
-                                "MAX_TEMPERATURE": {
-                                    "type": "float"
-                                },
-                                "MIN_TEMPERATURE": {
-                                    "type": "float"
-                                },
-                                "TOTAL_SNOWFALL": {
-                                    "type": "float"
-                                },
-                                "NORMAL_SNOWFALL": {
-                                    "type": "float"
-                                },
-                                "TOTAL_PRECIPITATION": {
-                                    "type": "float"
-                                },
-                                "NORMAL_PRECIPITATION": {
-                                    "type": "float"
-                                },
-                                "BRIGHT_SUNSHINE": {
-                                    "type": "float"
-                                },
-                                "NORMAL_SUNSHINE": {
-                                    "type": "float"
-                                },
-                                "SNOW_ON_GROUND_LAST_DAY": {
-                                    "type": "float"
-                                },
+                                "MEAN_TEMPERATURE": {"type": "float"},
+                                "NORMAL_MEAN_TEMPERATURE": {"type": "float"},
+                                "MAX_TEMPERATURE": {"type": "float"},
+                                "MIN_TEMPERATURE": {"type": "float"},
+                                "TOTAL_SNOWFALL": {"type": "float"},
+                                "NORMAL_SNOWFALL": {"type": "float"},
+                                "TOTAL_PRECIPITATION": {"type": "float"},
+                                "NORMAL_PRECIPITATION": {"type": "float"},
+                                "BRIGHT_SUNSHINE": {"type": "float"},
+                                "NORMAL_SUNSHINE": {"type": "float"},
+                                "SNOW_ON_GROUND_LAST_DAY": {"type": "float"},
                                 "DAYS_WITH_VALID_MIN_TEMP": {
                                     "type": "integer"
                                 },
@@ -468,580 +375,627 @@ def create_index(es, index):
                                 "DAYS_WITH_VALID_SNOWFALL": {
                                     "type": "integer"
                                 },
-                                "DAYS_WITH_VALID_PRECIP": {
-                                    "type": "integer"
-                                },
+                                "DAYS_WITH_VALID_PRECIP": {"type": "integer"},
                                 "DAYS_WITH_VALID_SUNSHINE": {
                                     "type": "integer"
                                 },
-                                "DAYS_WITH_PRECIP_GE_1MM": {
-                                    "type": "integer"
-                                },
-                                "HEATING_DEGREE_DAYS": {
-                                    "type": "integer"
-                                },
-                                "COOLING_DEGREE_DAYS": {
-                                    "type": "integer"
-                                },
-                                "LOCAL_YEAR": {
-                                    "type": "integer"
-                                },
-                                "LOCAL_MONTH": {
-                                    "type": "integer"
-                                },
+                                "DAYS_WITH_PRECIP_GE_1MM": {"type": "integer"},
+                                "HEATING_DEGREE_DAYS": {"type": "integer"},
+                                "COOLING_DEGREE_DAYS": {"type": "integer"},
+                                "LOCAL_YEAR": {"type": "integer"},
+                                "LOCAL_MONTH": {"type": "integer"},
                                 "LAST_UPDATED": {
                                     "type": "date",
-                                    "format": "yyyy-MM-dd HH:mm:ss"
+                                    "format": "yyyy-MM-dd HH:mm:ss",
                                 },
                                 "LOCAL_DATE": {
                                     "type": "date",
-                                    "format": "yyyy-MM"
-                                }
+                                    "format": "yyyy-MM",
+                                },
                             }
                         },
-                        "geometry": {"type": "geo_shape"}
-                    }
-                }
+                        "geometry": {"type": "geo_shape"},
+                    },
+                },
             }
 
-        index_name = 'climate_public_climate_summary'
+            index_name = 'climate_public_climate_summary'
 
-        if es.indices.exists(index_name):
-            es.indices.delete(index_name)
-            LOGGER.info('Deleted the climate monthly summaries index')
-        es.indices.create(index=index_name, body=mapping)
+            if self.ES.indices.exists(index_name):
+                self.ES.indices.delete(index_name)
+                LOGGER.info('Deleted the climate monthly summaries index')
+            self.ES.indices.create(index=index_name, body=mapping)
 
-    if index == 'daily_summary':
-        mapping =\
-            {
-                "settings": {
-                    "number_of_shards": 1,
-                    "number_of_replicas": 0
-                },
+        if index == 'daily_summary':
+            mapping = {
+                "settings": {"number_of_shards": 1, "number_of_replicas": 0},
                 "mappings": {
-                    "_meta": {
-                        "geomfields": {
-                            "geometry": "POINT"
-                        }
-                    },
+                    "_meta": {"geomfields": {"geometry": "POINT"}},
                     "properties": {
                         "type": {"type": "text"},
                         "properties": {
                             "properties": {
                                 "CLIMATE_IDENTIFIER": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "STN_ID": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "STATION_NAME": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "SOURCE": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "ID": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "MAX_TEMPERATURE_FLAG": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "MIN_TEMPERATURE_FLAG": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "MEAN_TEMPERATURE_FLAG": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "PROVINCE_CODE": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "MAX_REL_HUMIDITY_FLAG": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "MIN_REL_HUMIDITY_FLAG": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "TOTAL_RAIN_FLAG": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "TOTAL_SNOW_FLAG": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "TOTAL_PRECIPITATION_FLAG": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "SNOW_ON_GROUND_FLAG": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "DIRECTION_MAX_GUST_FLAG": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "SPEED_MAX_GUST_FLAG": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "HEATING_DEGREE_DAYS_FLAG": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "COOLING_DEGREE_DAYS_FLAG": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "MEAN_TEMPERATURE": {
-                                    "type": "float"
-                                },
-                                "TOTAL_RAIN": {
-                                    "type": "float"
-                                },
-                                "MAX_TEMPERATURE": {
-                                    "type": "float"
-                                },
-                                "MIN_TEMPERATURE": {
-                                    "type": "float"
-                                },
-                                "MAX_REL_HUMIDITY": {
-                                    "type": "float"
-                                },
-                                "MIN_REL_HUMIDITY": {
-                                    "type": "float"
-                                },
-                                "TOTAL_SNOW": {
-                                    "type": "float"
-                                },
-                                "SNOW_ON_GROUND": {
-                                    "type": "float"
-                                },
-                                "TOTAL_PRECIPITATION": {
-                                    "type": "float"
-                                },
-                                "DIRECTION_MAX_GUST": {
-                                    "type": "float"
-                                },
-                                "SPEED_MAX_GUST": {
-                                    "type": "float"
-                                },
-                                "HEATING_DEGREE_DAYS": {
-                                    "type": "integer"
-                                },
-                                "COOLING_DEGREE_DAYS": {
-                                    "type": "integer"
-                                },
-                                "LOCAL_YEAR": {
-                                    "type": "integer"
-                                },
-                                "LOCAL_MONTH": {
-                                    "type": "integer"
-                                },
-                                "LOCAL_DAY": {
-                                    "type": "integer"
-                                },
+                                "MEAN_TEMPERATURE": {"type": "float"},
+                                "TOTAL_RAIN": {"type": "float"},
+                                "MAX_TEMPERATURE": {"type": "float"},
+                                "MIN_TEMPERATURE": {"type": "float"},
+                                "MAX_REL_HUMIDITY": {"type": "float"},
+                                "MIN_REL_HUMIDITY": {"type": "float"},
+                                "TOTAL_SNOW": {"type": "float"},
+                                "SNOW_ON_GROUND": {"type": "float"},
+                                "TOTAL_PRECIPITATION": {"type": "float"},
+                                "DIRECTION_MAX_GUST": {"type": "float"},
+                                "SPEED_MAX_GUST": {"type": "float"},
+                                "HEATING_DEGREE_DAYS": {"type": "integer"},
+                                "COOLING_DEGREE_DAYS": {"type": "integer"},
+                                "LOCAL_YEAR": {"type": "integer"},
+                                "LOCAL_MONTH": {"type": "integer"},
+                                "LOCAL_DAY": {"type": "integer"},
                                 "LOCAL_DATE": {
                                     "type": "date",
-                                    "format": "yyyy-MM-dd HH:mm:ss"
-                                }
+                                    "format": "yyyy-MM-dd HH:mm:ss",
+                                },
                             }
                         },
-                        "geometry": {"type": "geo_shape"}
-                    }
-                }
+                        "geometry": {"type": "geo_shape"},
+                    },
+                },
             }
 
-        index_name = 'climate_public_daily_data'
+            index_name = 'climate_public_daily_data'
 
-        if es.indices.exists(index_name):
-            es.indices.delete(index_name)
-            LOGGER.info('Deleted the climate daily summaries index')
-        es.indices.create(index=index_name, body=mapping)
+            if self.ES.indices.exists(index_name):
+                self.ES.indices.delete(index_name)
+                LOGGER.info('Deleted the climate daily summaries index')
+            self.ES.indices.create(index=index_name, body=mapping)
 
+    def generate_stations(self):
+        """
+        Queries stations data from the db, and reformats
+        data so it can be inserted into Elasticsearch.
 
-def generate_stations(cur):
-    """
-    Queries stations data from the db, and reformats
-    data so it can be inserted into Elasticsearch.
+        Returns a generator of dictionaries that represent upsert actions
+        into Elasticsearch's bulk API.
 
-    Returns a generator of dictionaries that represent upsert actions
-    into Elasticsearch's bulk API.
+        :param cur: oracle cursor to perform queries against.
+        :returns: generator of bulk API upsert actions.
+        """
 
-    :param cur: oracle cursor to perform queries against.
-    :returns: generator of bulk API upsert actions.
-    """
+        try:
+            self.cur.execute('select * from CCCS_PORTAL.STATION_INFORMATION')
+        except Exception as err:
+            LOGGER.error(
+                f'Could not fetch records from oracle due to: {str(err)}.'
+            )
 
-    try:
-        cur.execute('select * from CCCS_PORTAL.STATION_INFORMATION')
-    except Exception as err:
-        LOGGER.error('Could not fetch records from oracle due to: {}.'.format(str(err))) # noqa
+        for row in self.cur:
+            insert_dict = dict(zip([x[0] for x in self.cur.description], row))
+            for key in insert_dict:
+                # This is a quick fix for trailing spaces and should not be
+                # here. Data should be fixed on db side.
+                try:
+                    insert_dict[key] = insert_dict[key].strip()
+                except Exception as err:
+                    LOGGER.debug(
+                        f'Could not strip value {insert_dict[key]} due to '
+                        f'{str(err)}, skipping'
+                    )
 
-    for row in cur:
-        insert_dict = dict(zip([x[0] for x in cur.description], row))
-        for key in insert_dict:
-            # This is a quick fix for trailing spaces and should not be here.
-            # Data should be fixed on db side.
-            try:
-                insert_dict[key] = insert_dict[key].strip()
-            except Exception as err:
-                LOGGER.debug('Could not strip value {} due to {}, skipping'.format(insert_dict[key], str(err))) # noqa
+                # Transform Date fields from datetime to string.
+                if 'DATE' in key:
+                    insert_dict[key] = (
+                        str(insert_dict[key])
+                        if insert_dict[key] is not None
+                        else insert_dict[key]
+                    )
 
-            # Transform Date fields from datetime to string.
-            if 'DATE' in key:
-                insert_dict[key] = str(insert_dict[key]) if insert_dict[key] is not None else insert_dict[key] # noqa
+            coords = [
+                float(insert_dict['LONGITUDE_DECIMAL_DEGREES']),
+                float(insert_dict['LATITUDE_DECIMAL_DEGREES']),
+            ]
+            del insert_dict['LONGITUDE_DECIMAL_DEGREES']
+            del insert_dict['LATITUDE_DECIMAL_DEGREES']
+            climate_identifier = insert_dict['CLIMATE_IDENTIFIER']
+            wrapper = {
+                'type': 'Feature',
+                'properties': insert_dict,
+                'geometry': {'type': 'Point', 'coordinates': coords},
+            }
 
-        coords = [float(insert_dict['LONGITUDE_DECIMAL_DEGREES']),
-                  float(insert_dict['LATITUDE_DECIMAL_DEGREES'])]
-        del insert_dict['LONGITUDE_DECIMAL_DEGREES']
-        del insert_dict['LATITUDE_DECIMAL_DEGREES']
-        climate_identifier = insert_dict['CLIMATE_IDENTIFIER']
-        wrapper = {
-            'type': 'Feature',
-            'properties': insert_dict,
-            'geometry': {'type': 'Point', 'coordinates': coords}
-        }
-
-        action = {
-            '_id': climate_identifier,
-            '_index': 'climate_station_information',
-            '_op_type': 'update',
-            'doc': wrapper,
-            'doc_as_upsert': True
-        }
-        yield action
-
-
-def generate_normals(cur, stn_dict, normals_dict, periods_dict):
-    """
-    Queries normals data from the db, and reformats
-    data so it can be inserted into Elasticsearch.
-
-    Returns a generator of dictionaries that represent upsert actions
-    into Elasticsearch's bulk API.
-
-    :param cur: oracle cursor to perform queries against.
-    :param stn_dict: mapping of station IDs to station information.
-    :param normals_dict: mapping of normal IDs to normals information.
-    :param periods_dict: mapping of normal period IDs to
-                         normal period information.
-    :returns: generator of bulk API upsert actions.
-    """
-
-    try:
-        cur.execute('select * from CCCS_PORTAL.NORMALS_DATA')
-    except Exception as err:
-        LOGGER.error('Could not fetch records from oracle due to: {}.'.format(str(err))) # noqa
-
-    for row in cur:
-        insert_dict = dict(zip([x[0] for x in cur.description], row))
-
-        for key in insert_dict:
-            # Transform Date fields from datetime to string.
-            if 'DATE' in key:
-                insert_dict[key] = str(insert_dict[key]) if insert_dict[key] is not None else insert_dict[key] # noqa
-        insert_dict['ID'] = '{}.{}.{}'.format(insert_dict['STN_ID'],
-                                              insert_dict['NORMAL_ID'],
-                                              insert_dict['MONTH'])
-        if insert_dict['STN_ID'] in stn_dict:
-            coords = stn_dict[insert_dict['STN_ID']]['coordinates']
-            insert_dict['STATION_NAME'] = stn_dict[insert_dict['STN_ID']]['STATION_NAME'] # noqa
-            insert_dict['PROVINCE_CODE'] = stn_dict[insert_dict['STN_ID']]['PROVINCE_CODE'] # noqa
-            insert_dict['E_NORMAL_ELEMENT_NAME'] = normals_dict[insert_dict['NORMAL_ID']]['E_NORMAL_ELEMENT_NAME'] # noqa
-            insert_dict['F_NORMAL_ELEMENT_NAME'] = normals_dict[insert_dict['NORMAL_ID']]['F_NORMAL_ELEMENT_NAME'] # noqa
-            insert_dict['PERIOD'] = normals_dict[insert_dict['NORMAL_ID']]['PERIOD'] # noqa
-            insert_dict['PERIOD_BEGIN'] = periods_dict[insert_dict['NORMAL_PERIOD_ID']]['PERIOD_BEGIN'] # noqa
-            insert_dict['PERIOD_END'] = periods_dict[insert_dict['NORMAL_PERIOD_ID']]['PERIOD_END'] # noqa
-            insert_dict['CLIMATE_IDENTIFIER'] = stn_dict[insert_dict['STN_ID']]['CLIMATE_IDENTIFIER'] # noqa
-
-            del insert_dict['NORMAL_PERIOD_ID']
-            wrapper = {'type': 'Feature', 'properties': insert_dict,
-                       'geometry': {'type': 'Point', 'coordinates': coords}}
             action = {
-                '_id': insert_dict['ID'],
-                '_index': 'climate_normals_data',
+                '_id': climate_identifier,
+                '_index': 'climate_station_information',
                 '_op_type': 'update',
                 'doc': wrapper,
-                'doc_as_upsert': True
+                'doc_as_upsert': True,
             }
             yield action
-        else:
-            LOGGER.error('Bad STN ID: {}, skipping records for this station'.format(insert_dict['STN_ID'])) # noqa
 
+    def generate_normals(self, stn_dict, normals_dict, periods_dict):
+        """
+        Queries normals data from the db, and reformats
+        data so it can be inserted into Elasticsearch.
 
-def generate_monthly_data(cur, stn_dict, date=None):
-    """
-    Queries monthly data from the db, and reformats
-    data so it can be inserted into Elasticsearch.
+        Returns a generator of dictionaries that represent upsert actions
+        into Elasticsearch's bulk API.
 
-    Returns a generator of dictionaries that represent upsert actions
-    into Elasticsearch's bulk API.
+        :param cur: oracle cursor to perform queries against.
+        :param stn_dict: mapping of station IDs to station information.
+        :param normals_dict: mapping of normal IDs to normals information.
+        :param periods_dict: mapping of normal period IDs to
+                            normal period information.
+        :returns: generator of bulk API upsert actions.
+        """
 
-    :param cur: oracle cursor to perform queries against.
-    :param stn_dict: mapping of station IDs to station information.
-    :param date: date to start fetching data from.
-    :returns: generator of bulk API upsert actions.
-    """
-
-    if not date:
         try:
-            cur.execute('select * from CCCS_PORTAL.PUBLIC_CLIMATE_SUMMARY')
+            self.cur.execute('select * from CCCS_PORTAL.NORMALS_DATA')
         except Exception as err:
-            LOGGER.error('Could not fetch records from oracle due to: {}.'.format(str(err))) # noqa
-    else:
-        try:
-            cur.execute("select * from CCCS_PORTAL.PUBLIC_CLIMATE_SUMMARY WHERE LAST_UPDATED > TO_TIMESTAMP('{} 00:00:00', 'YYYY-MM-DD HH24:MI:SS')".format(date)) # noqa
-        except Exception as err:
-            LOGGER.error('Could not fetch records from oracle due to: {}.'.format(str(err))) # noqa
+            LOGGER.error(
+                f'Could not fetch records from oracle due to: {str(err)}.'
+            )
 
-    for row in cur:
-        insert_dict = dict(zip([x[0] for x in cur.description], row))
-        # Transform Date fields from datetime to string.
-        insert_dict['LAST_UPDATED'] = str(insert_dict['LAST_UPDATED']) if insert_dict['LAST_UPDATED'] is not None else insert_dict['LAST_UPDATED'] # noqa
+        for row in self.cur:
+            insert_dict = dict(zip([x[0] for x in self.cur.description], row))
 
-        insert_dict['ID'] = '{}.{}.{}'.format(insert_dict['STN_ID'],
-                                              insert_dict['LOCAL_YEAR'],
-                                              insert_dict['LOCAL_MONTH'])
-        if insert_dict['STN_ID'] in stn_dict:
-            coords = stn_dict[insert_dict['STN_ID']]['coordinates']
-            insert_dict['PROVINCE_CODE'] = stn_dict[insert_dict['STN_ID']]['PROVINCE_CODE'] # noqa
-            wrapper = {'type': 'Feature', 'properties': insert_dict,
-                       'geometry': {'type': 'Point', 'coordinates': coords}}
-            action = {
-                '_id': insert_dict['ID'],
-                '_index': 'climate_public_climate_summary',
-                '_op_type': 'update',
-                'doc': wrapper,
-                'doc_as_upsert': True
-            }
-            yield action
-        else:
-            LOGGER.error('Bad STN ID: {}, skipping records for this station'.format(insert_dict['STN_ID'])) # noqa
-
-
-def generate_daily_data(cur, stn_dict, date=None):
-    """
-    Queries daily data from the db, and reformats
-    data so it can be inserted into Elasticsearch.
-
-    Returns a generator of dictionaries that represent upsert actions
-    into Elasticsearch's bulk API.
-
-    :param cur: oracle cursor to perform queries against.
-    :param stn_dict: mapping of station IDs to station information.
-    :param date: date to start fetching data from.
-    :returns: generator of bulk API upsert actions.
-    """
-
-    for station in stn_dict:
-        if not date:
-            try:
-                cur.execute('select * from CCCS_PORTAL.PUBLIC_DAILY_DATA where STN_ID={}'.format(station)) # noqa
-            except Exception as err:
-                LOGGER.error('Could not fetch records from oracle due to: {}.'.format(str(err))) # noqa
-        else:
-            try:
-                cur.execute("select * from CCCS_PORTAL.PUBLIC_DAILY_DATA where STN_ID={} and LOCAL_DATE > TO_TIMESTAMP('{} 00:00:00', 'YYYY-MM-DD HH24:MI:SS')".format(station, date)) # noqa
-            except Exception as err:
-                LOGGER.error('Could not fetch records from oracle due to: {}.'.format(str(err))) # noqa
-
-        for row in cur:
-            insert_dict = dict(zip([x[0] for x in cur.description], row))
-            # Transform Date fields from datetime to string.
-            insert_dict['LOCAL_DATE'] = str(insert_dict['LOCAL_DATE']) if insert_dict['LOCAL_DATE'] is not None else insert_dict['LOCAL_DATE'] # noqa
-
-            insert_dict['ID'] = '{}.{}.{}.{}'.format(
-                insert_dict['CLIMATE_IDENTIFIER'],
-                insert_dict['LOCAL_YEAR'],
-                insert_dict['LOCAL_MONTH'], # noqa
-                insert_dict['LOCAL_DAY'])
+            for key in insert_dict:
+                # Transform Date fields from datetime to string.
+                if 'DATE' in key:
+                    insert_dict[key] = (
+                        str(insert_dict[key])
+                        if insert_dict[key] is not None
+                        else insert_dict[key]
+                    )
+            insert_dict['ID'] = '{}.{}.{}'.format(
+                insert_dict['STN_ID'],
+                insert_dict['NORMAL_ID'],
+                insert_dict['MONTH'],
+            )
             if insert_dict['STN_ID'] in stn_dict:
                 coords = stn_dict[insert_dict['STN_ID']]['coordinates']
-                insert_dict['PROVINCE_CODE'] = stn_dict[insert_dict['STN_ID']]['PROVINCE_CODE'] # noqa
-                insert_dict['STATION_NAME'] = stn_dict[insert_dict['STN_ID']]['STATION_NAME'] # noqa
-                wrapper = {'type': 'Feature', 'properties': insert_dict,
-                           'geometry': {'type': 'Point',
-                                        'coordinates': coords}}
+                insert_dict['STATION_NAME'] = stn_dict[insert_dict['STN_ID']][
+                    'STATION_NAME'
+                ]
+                insert_dict['PROVINCE_CODE'] = stn_dict[insert_dict['STN_ID']][
+                    'PROVINCE_CODE'
+                ]
+                insert_dict['E_NORMAL_ELEMENT_NAME'] = normals_dict[
+                    insert_dict['NORMAL_ID']
+                ]['E_NORMAL_ELEMENT_NAME']
+                insert_dict['F_NORMAL_ELEMENT_NAME'] = normals_dict[
+                    insert_dict['NORMAL_ID']
+                ]['F_NORMAL_ELEMENT_NAME']
+                insert_dict['PERIOD'] = normals_dict[insert_dict['NORMAL_ID']][
+                    'PERIOD'
+                ]
+                insert_dict['PERIOD_BEGIN'] = periods_dict[
+                    insert_dict['NORMAL_PERIOD_ID']
+                ]['PERIOD_BEGIN']
+                insert_dict['PERIOD_END'] = periods_dict[
+                    insert_dict['NORMAL_PERIOD_ID']
+                ]['PERIOD_END']
+                insert_dict['CLIMATE_IDENTIFIER'] = stn_dict[
+                    insert_dict['STN_ID']
+                ]['CLIMATE_IDENTIFIER']
+
+                del insert_dict['NORMAL_PERIOD_ID']
+                wrapper = {
+                    'type': 'Feature',
+                    'properties': insert_dict,
+                    'geometry': {'type': 'Point', 'coordinates': coords},
+                }
                 action = {
                     '_id': insert_dict['ID'],
-                    '_index': 'climate_public_daily_data',
+                    '_index': 'climate_normals_data',
                     '_op_type': 'update',
                     'doc': wrapper,
-                    'doc_as_upsert': True
+                    'doc_as_upsert': True,
                 }
                 yield action
             else:
-                LOGGER.error('Bad STN ID: {}, skipping records for this station'.format(insert_dict['STN_ID'])) # noqa
+                LOGGER.error(
+                    f"Bad STN ID: {insert_dict['STN_ID']}, skipping"
+                    f" records for this station"
+                )
 
+    def generate_monthly_data(self, stn_dict, date=None):
+        """
+        Queries monthly data from the db, and reformats
+        data so it can be inserted into Elasticsearch.
 
-def get_station_data(cur, station, starting_from):
-    """
-    Creates a mapping of station ID to station coordinates and province name.
+        Returns a generator of dictionaries that represent upsert actions
+        into Elasticsearch's bulk API.
 
-    :param cur: oracle cursor to perform queries against.
+        :param cur: oracle cursor to perform queries against.
+        :param stn_dict: mapping of station IDs to station information.
+        :param date: date to start fetching data from.
+        :returns: generator of bulk API upsert actions.
+        """
 
-    :returns: A dictionary of dictionaries containing
-              station coordinates and province name keyed by station ID.
-    """
-    stn_dict = collections.OrderedDict()
-    try:
-        if station:
-            if starting_from:
-                cur.execute('select STN_ID, LONGITUDE_DECIMAL_DEGREES,\
-                             LATITUDE_DECIMAL_DEGREES,\
-                             ENG_PROV_NAME, FRE_PROV_NAME,\
-                             PROV_STATE_TERR_CODE,\
-                             STATION_NAME, CLIMATE_IDENTIFIER from\
-                             CCCS_PORTAL.STATION_INFORMATION\
-                             where STN_ID >= {}\
-                             order by STN_ID'.format(station))
-            else:
-                cur.execute('select STN_ID, LONGITUDE_DECIMAL_DEGREES,\
-                             LATITUDE_DECIMAL_DEGREES,\
-                             ENG_PROV_NAME, FRE_PROV_NAME,\
-                             PROV_STATE_TERR_CODE,\
-                             STATION_NAME, CLIMATE_IDENTIFIER from\
-                             CCCS_PORTAL.STATION_INFORMATION\
-                             where STN_ID = {}\
-                             order by STN_ID'.format(station))
+        if not date:
+            try:
+                self.cur.execute(
+                    'select * from CCCS_PORTAL.PUBLIC_CLIMATE_SUMMARY'
+                )
+            except Exception as err:
+                LOGGER.error(
+                    f'Could not fetch records from oracle due to: {str(err)}.'
+                )
         else:
-            cur.execute('select STN_ID, LONGITUDE_DECIMAL_DEGREES,\
-                         LATITUDE_DECIMAL_DEGREES,\
-                         ENG_PROV_NAME, FRE_PROV_NAME,\
-                         PROV_STATE_TERR_CODE,\
-                         STATION_NAME, CLIMATE_IDENTIFIER from\
-                         CCCS_PORTAL.STATION_INFORMATION\
-                         order by STN_ID')
-    except Exception as err:
-        LOGGER.error('Could not fetch records from oracle due to: {}.'.format(str(err))) # noqa
+            try:
+                self.cur.execute(
+                    (
+                        f"select * from CCCS_PORTAL.PUBLIC_CLIMATE_SUMMARY "
+                        f"WHERE LAST_UPDATED > TO_TIMESTAMP("
+                        f"'{date} 00:00:00', 'YYYY-MM-DD HH24:MI:SS')"
+                    )
+                )
+            except Exception as err:
+                LOGGER.error(
+                    f'Could not fetch records from oracle due to: {str(err)}.'
+                )
 
-    for row in cur:
-        stn_dict[row[0]] = {'coordinates': [row[1], row[2]],
-                            'ENG_PROV_NAME': row[3],
-                            'FRE_PROV_NAME': row[4],
-                            'PROVINCE_CODE': row[5].strip(),  # remove the strip # noqa
-                            'STATION_NAME': row[6],
-                            'CLIMATE_IDENTIFIER': row[7].strip()
-                            }
-    return stn_dict
+        for row in self.cur:
+            insert_dict = dict(zip([x[0] for x in self.cur.description], row))
+            # Transform Date fields from datetime to string.
+            insert_dict['LAST_UPDATED'] = (
+                str(insert_dict['LAST_UPDATED'])
+                if insert_dict['LAST_UPDATED'] is not None
+                else insert_dict['LAST_UPDATED']
+            )
+
+            insert_dict['ID'] = '{}.{}.{}'.format(
+                insert_dict['STN_ID'],
+                insert_dict['LOCAL_YEAR'],
+                insert_dict['LOCAL_MONTH'],
+            )
+            if insert_dict['STN_ID'] in stn_dict:
+                coords = stn_dict[insert_dict['STN_ID']]['coordinates']
+                insert_dict['PROVINCE_CODE'] = stn_dict[insert_dict['STN_ID']][
+                    'PROVINCE_CODE'
+                ]
+                wrapper = {
+                    'type': 'Feature',
+                    'properties': insert_dict,
+                    'geometry': {'type': 'Point', 'coordinates': coords},
+                }
+                action = {
+                    '_id': insert_dict['ID'],
+                    '_index': 'climate_public_climate_summary',
+                    '_op_type': 'update',
+                    'doc': wrapper,
+                    'doc_as_upsert': True,
+                }
+                yield action
+            else:
+                LOGGER.error(
+                    f"Bad STN ID: {insert_dict['STN_ID']}, skipping"
+                    f" records for this station"
+                )
+
+    def generate_daily_data(self, stn_dict, date=None):
+        """
+        Queries daily data from the db, and reformats
+        data so it can be inserted into Elasticsearch.
+
+        Returns a generator of dictionaries that represent upsert actions
+        into Elasticsearch's bulk API.
+
+        :param cur: oracle cursor to perform queries against.
+        :param stn_dict: mapping of station IDs to station information.
+        :param date: date to start fetching data from.
+        :returns: generator of bulk API upsert actions.
+        """
+
+        for station in stn_dict:
+            if not date:
+                try:
+                    self.cur.execute(
+                        f'select * from CCCS_PORTAL.PUBLIC_DAILY_DATA '
+                        f'where STN_ID={station}'
+                    )
+                except Exception as err:
+                    LOGGER.error(
+                        f'Could not fetch records from oracle due to:'
+                        f' {str(err)}.'
+                    )
+            else:
+                try:
+                    self.cur.execute(
+                        (
+                            f"select * from CCCS_PORTAL.PUBLIC_DAILY_DATA "
+                            f"where STN_ID={station} and "
+                            f"LOCAL_DATE > TO_TIMESTAMP('{date} 00:00:00', "
+                            f"'YYYY-MM-DD HH24:MI:SS')"
+                        )
+                    )
+                except Exception as err:
+                    LOGGER.error(
+                        f'Could not fetch records from oracle due to:'
+                        f' {str(err)}.'
+                    )
+
+            for row in self.cur:
+                insert_dict = dict(
+                    zip([x[0] for x in self.cur.description], row)
+                )
+                # Transform Date fields from datetime to string.
+                insert_dict['LOCAL_DATE'] = (
+                    str(insert_dict['LOCAL_DATE'])
+                    if insert_dict['LOCAL_DATE'] is not None
+                    else insert_dict['LOCAL_DATE']
+                )
+
+                insert_dict['ID'] = '{}.{}.{}.{}'.format(
+                    insert_dict['CLIMATE_IDENTIFIER'],
+                    insert_dict['LOCAL_YEAR'],
+                    insert_dict['LOCAL_MONTH'],
+                    insert_dict['LOCAL_DAY'],
+                )
+                if insert_dict['STN_ID'] in stn_dict:
+                    coords = stn_dict[insert_dict['STN_ID']]['coordinates']
+                    insert_dict['PROVINCE_CODE'] = stn_dict[
+                        insert_dict['STN_ID']
+                    ]['PROVINCE_CODE']
+                    insert_dict['STATION_NAME'] = stn_dict[
+                        insert_dict['STN_ID']
+                    ]['STATION_NAME']
+                    wrapper = {
+                        'type': 'Feature',
+                        'properties': insert_dict,
+                        'geometry': {'type': 'Point', 'coordinates': coords},
+                    }
+                    action = {
+                        '_id': insert_dict['ID'],
+                        '_index': 'climate_public_daily_data',
+                        '_op_type': 'update',
+                        'doc': wrapper,
+                        'doc_as_upsert': True,
+                    }
+                    yield action
+                else:
+                    LOGGER.error(
+                        f"Bad STN ID: {insert_dict['STN_ID']}, skipping"
+                        f" records for this station"
+                    )
+
+    def get_station_data(self, station, starting_from):
+        """
+        Creates a mapping of station ID to station coordinates and province
+        name.
+
+        :param cur: oracle cursor to perform queries against.
+
+        :returns: A dictionary of dictionaries containing
+                station coordinates and province name keyed by station ID.
+        """
+        stn_dict = collections.OrderedDict()
+        try:
+            if station:
+                if starting_from:
+                    self.cur.execute(
+                        (
+                            f'select STN_ID, LONGITUDE_DECIMAL_DEGREES, '
+                            f'LATITUDE_DECIMAL_DEGREES, ENG_PROV_NAME, '
+                            f'FRE_PROV_NAME, PROV_STATE_TERR_CODE, '
+                            f'STATION_NAME, CLIMATE_IDENTIFIER '
+                            f'from CCCS_PORTAL.STATION_INFORMATION '
+                            f'where STN_ID >= {station} '
+                            f'order by STN_ID'
+                        )
+                    )
+                else:
+                    self.cur.execute(
+                        (
+                            f'select STN_ID, LONGITUDE_DECIMAL_DEGREES, '
+                            f'LATITUDE_DECIMAL_DEGREES, ENG_PROV_NAME, '
+                            f'FRE_PROV_NAME, PROV_STATE_TERR_CODE, '
+                            f'STATION_NAME, CLIMATE_IDENTIFIER '
+                            f'from CCCS_PORTAL.STATION_INFORMATION '
+                            f'where STN_ID = {station} '
+                            f'order by STN_ID'
+                        )
+                    )
+            else:
+                self.cur.execute(
+                    (
+                        'select STN_ID, LONGITUDE_DECIMAL_DEGREES, '
+                        'LATITUDE_DECIMAL_DEGREES, ENG_PROV_NAME, '
+                        'FRE_PROV_NAME, PROV_STATE_TERR_CODE, '
+                        'STATION_NAME, CLIMATE_IDENTIFIER '
+                        'from CCCS_PORTAL.STATION_INFORMATION '
+                        'order by STN_ID'
+                    )
+                )
+        except Exception as err:
+            LOGGER.error(
+                f'Could not fetch records from oracle due to: {str(err)}.'
+            )
+
+        for row in self.cur:
+            stn_dict[row[0]] = {
+                'coordinates': [row[1], row[2]],
+                'ENG_PROV_NAME': row[3],
+                'FRE_PROV_NAME': row[4],
+                'PROVINCE_CODE': row[5].strip(),  # remove the strip
+                'STATION_NAME': row[6],
+                'CLIMATE_IDENTIFIER': row[7].strip(),
+            }
+        return stn_dict
+
+    def get_normals_data(self):
+        """
+        Creates a mapping of normal ID to pub_name and period.
+
+        :param cur: oracle cursor to perform queries against.
+
+        :returns: A dictionary of dictionaries containing
+                pub_name and period keyed by normal ID.
+        """
+        normals_dict = {}
+        try:
+            self.cur.execute(
+                (
+                    'select NORMAL_ID, E_NORMAL_ELEMENT_NAME, '
+                    'F_NORMAL_ELEMENT_NAME, PERIOD '
+                    'from CCCS_PORTAL.VALID_NORMALS_ELEMENTS'
+                )
+            )
+        except Exception as err:
+            LOGGER.error(
+                f'Could not fetch records from oracle due to: {str(err)}.'
+            )
+
+        for row in self.cur:
+            normals_dict[row[0]] = {
+                'E_NORMAL_ELEMENT_NAME': row[1],
+                'F_NORMAL_ELEMENT_NAME': row[2],
+                'PERIOD': row[3],
+            }
+        return normals_dict
+
+    def get_normals_periods(self):
+        """
+        Creates a mapping of normal period ID to period begin and end.
+
+        :param cur: oracle cursor to perform queries against.
+
+        :returns: A dictionary of dictionaries containing
+                period begin and end keyed by normal period ID.
+        """
+        period_dict = {}
+        try:
+            self.cur.execute(
+                (
+                    'select NORMAL_PERIOD_ID, PERIOD_BEGIN, PERIOD_END '
+                    'from CCCS_PORTAL.NORMAL_PERIODS'
+                )
+            )
+        except Exception as err:
+            LOGGER.error(
+                f'Could not fetch records from oracle due to: {str(err)}.'
+            )
+
+        for row in self.cur:
+            period_dict[row[0]] = {
+                'PERIOD_BEGIN': row[1],
+                'PERIOD_END': row[2],
+            }
+        return period_dict
 
 
-def get_normals_data(cur):
-    """
-    Creates a mapping of normal ID to pub_name and period.
-
-    :param cur: oracle cursor to perform queries against.
-
-    :returns: A dictionary of dictionaries containing
-              pub_name and period keyed by normal ID.
-    """
-    normals_dict = {}
-    try:
-        cur.execute('select NORMAL_ID, E_NORMAL_ELEMENT_NAME,\
-                     F_NORMAL_ELEMENT_NAME, PERIOD from\
-                     CCCS_PORTAL.VALID_NORMALS_ELEMENTS')
-    except Exception as err:
-        LOGGER.error('Could not fetch records from oracle due to: {}.'.format(str(err))) # noqa
-
-    for row in cur:
-        normals_dict[row[0]] = {'E_NORMAL_ELEMENT_NAME': row[1],
-                                'F_NORMAL_ELEMENT_NAME': row[2],
-                                'PERIOD': row[3]
-                                }
-    return normals_dict
-
-
-def get_normals_periods(cur):
-    """
-    Creates a mapping of normal period ID to period begin and end.
-
-    :param cur: oracle cursor to perform queries against.
-
-    :returns: A dictionary of dictionaries containing
-              period begin and end keyed by normal period ID.
-    """
-    period_dict = {}
-    try:
-        cur.execute('select NORMAL_PERIOD_ID, PERIOD_BEGIN,\
-                     PERIOD_END from\
-                     CCCS_PORTAL.NORMAL_PERIODS')
-    except Exception as err:
-        LOGGER.error('Could not fetch records from oracle due to: {}.'.format(str(err))) # noqa
-
-    for row in cur:
-        period_dict[row[0]] = {'PERIOD_BEGIN': row[1],
-                               'PERIOD_END': row[2]
-                               }
-    return period_dict
+@click.group()
+def climate_archive():
+    """Manages Cliamte Archive indices"""
+    pass
 
 
 @click.command()
 @click.pass_context
-@click.option('--db', help='Oracle database connection string.')
-@click.option('--es', help='URL to Elasticsearch.')
-@click.option('--username', help='Username to connect to HTTPS')
-@click.option('--password', help='Password to connect to HTTPS')
-@click.option('--dataset', help='ES dataset to load, or all\
-                                 if loading everything')
-@click.option('--station', help='station ID (STN_ID) of\
-                                 station to load', required=False)
-@click.option('--starting_from',
-              help=' Load all stations starting from specified station',
-              required=False)
+@cli_options.OPTION_DB()
+@cli_options.OPTION_ELASTICSEARCH()
+@cli_options.OPTION_ES_USERNAME()
+@cli_options.OPTION_ES_PASSWORD()
+@cli_options.OPTION_DATASET(
+    type=click.Choice(['all', 'stations', 'normals', 'monthly', 'daily']),
+)
+@click.option(
+    '--station', help='station ID (STN_ID) of station to load', required=False,
+)
+@click.option(
+    '--starting_from',
+    help=' Load all stations starting from specified station',
+    required=False,
+)
 @click.option('--date', help='Start date to fetch updates', required=False)
-def climate_archive(ctx, db, es, username, password, dataset, station=None,
-                    starting_from=False, date=None):
+def add(
+    ctx,
+    db,
+    es,
+    username,
+    password,
+    dataset,
+    station=None,
+    starting_from=False,
+    date=None,
+):
     """
-    Loads MSC Climate Archive data into Elasticsearch
+    Loads MSC Climate Archive data into Elasticsearch.
 
     Controls transformation from oracle to Elasticsearch.
 
@@ -1055,121 +1009,133 @@ def climate_archive(ctx, db, es, username, password, dataset, station=None,
     :param date: date to start fetching daily and monthly data from.
     """
 
-    auth = (username, password)
-    es_client = util.get_es(es, auth)
+    plugin_def = {
+        'db_conn_string': db,
+        'es_conn_dict': {'host': es, 'auth': (username, password)}
+        if all([es, username, password])
+        else None,
+        'handler': 'msc_pygeoapi.loader.climate_archive.ClimateArchiveLoader',
+    }
 
-    try:
-        con = cx_Oracle.connect(db)
-    except Exception as err:
-        msg = 'Could not connect to Oracle: {}'.format(err)
-        LOGGER.critical(msg)
-        raise click.ClickException(msg)
-
-    cur = con.cursor()
+    loader = ClimateArchiveLoader(plugin_def)
 
     if dataset == 'all':
-        stn_dict = get_station_data(cur, station, starting_from)
-        normals_dict = get_normals_data(cur)
-        periods_dict = get_normals_periods(cur)
+        stn_dict = loader.get_station_data(station, starting_from)
+        normals_dict = loader.get_normals_data()
+        periods_dict = loader.get_normals_periods()
 
         try:
             LOGGER.info('Populating stations...')
-            create_index(es_client, 'stations')
-            stations = generate_stations(cur)
+            loader.create_index('stations')
+            stations = loader.generate_stations()
 
-            util.submit_elastic_package(es_client, stations)
+            submit_elastic_package(loader.ES, stations)
             LOGGER.info('Stations populated.')
         except Exception as err:
-            LOGGER.error('Could not populate stations due to: {}.'.format(str(err))) # noqa
-
+            LOGGER.error(f'Could not populate stations due to: {str(err)}.')
         try:
             LOGGER.info('Populating normals...')
-            create_index(es_client, 'normals')
-            normals = generate_normals(cur, stn_dict, normals_dict,
-                                       periods_dict)
+            loader.create_index('normals')
+            normals = loader.generate_normals(
+                stn_dict, normals_dict, periods_dict
+            )
 
-            util.submit_elastic_package(es_client, normals)
+            submit_elastic_package(loader.ES, normals)
             LOGGER.info('Normals populated.')
         except Exception as err:
-            LOGGER.error('Could not populate normals due to: {}.'.format(str(err))) # noqa    
+            LOGGER.error(f'Could not populate normals due to: {str(err)}.')
 
         try:
             LOGGER.info('Populating monthly summary...')
             if not date:
-                create_index(es_client, 'monthly_summary')
-            monthlies = generate_monthly_data(cur, stn_dict, date)
+                loader.create_index('monthly_summary')
+            monthlies = loader.generate_monthly_data(stn_dict, date)
 
-            util.submit_elastic_package(es_client, monthlies)
+            submit_elastic_package(loader.ES, monthlies)
             LOGGER.info('Monthly Summary populated.')
         except Exception as err:
-            LOGGER.error('Could not populate monthly summary due to: {}.'.format(str(err))) # noqa
+            LOGGER.error(
+                f'Could not populate monthly summary due to: {str(err)}.'
+            )
 
         try:
             LOGGER.info('Populating daily summary...')
             if not date:
-                create_index(es_client, 'daily_summary')
-            dailies = generate_daily_data(cur, stn_dict, date)
+                loader.create_index('daily_summary')
+            dailies = loader.generate_daily_data(stn_dict, date)
 
-            util.submit_elastic_package(es_client, dailies)
+            submit_elastic_package(loader.ES, dailies)
             LOGGER.info('Daily Summary populated.')
         except Exception as err:
-            LOGGER.error('Could not populate daily summary due to: {}.'.format(str(err))) # noqa
+            LOGGER.error(
+                f'Could not populate daily summary due to: {str(err)}.'
+            )
 
     elif dataset == 'stations':
         try:
             LOGGER.info('Populating stations...')
-            create_index(es_client, 'stations')
-            stations = generate_stations(cur)
+            loader.create_index('stations')
+            stations = loader.generate_stations()
 
-            util.submit_elastic_package(es_client, stations)
+            submit_elastic_package(loader.ES, stations)
             LOGGER.info('Stations populated.')
         except Exception as err:
-            LOGGER.error('Could not populate stations due to: {}.'.format(str(err))) # noqa
+            LOGGER.error(f'Could not populate stations due to: {str(err)}.')
 
     elif dataset == 'normals':
         try:
             LOGGER.info('Populating normals...')
-            stn_dict = get_station_data(cur, station, starting_from)
-            normals_dict = get_normals_data(cur)
-            periods_dict = get_normals_periods(cur)
-            create_index(es_client, 'normals')
-            normals = generate_normals(cur, stn_dict, normals_dict,
-                                       periods_dict)
+            stn_dict = loader.get_station_data(station, starting_from)
+            normals_dict = loader.get_normals_data()
+            periods_dict = loader.get_normals_periods()
+            loader.create_index('normals')
+            normals = loader.generate_normals(
+                stn_dict, normals_dict, periods_dict
+            )
 
-            util.submit_elastic_package(es_client, normals)
+            submit_elastic_package(loader.ES, normals)
             LOGGER.info('Normals populated.')
         except Exception as err:
-            LOGGER.error('Could not populate normals due to: {}.'.format(str(err))) # noqa
+            LOGGER.error(f'Could not populate normals due to: {str(err)}.')
 
     elif dataset == 'monthly':
         try:
             LOGGER.info('Populating monthly summary...')
-            stn_dict = get_station_data(cur, station, starting_from)
+            stn_dict = loader.get_station_data(station, starting_from)
             if not (date or station or starting_from):
-                create_index(es_client, 'monthly_summary')
-            monthlies = generate_monthly_data(cur, stn_dict, date)
+                loader.create_index('monthly_summary')
+            monthlies = loader.generate_monthly_data(stn_dict, date)
 
-            util.submit_elastic_package(es_client, monthlies)
+            submit_elastic_package(loader.ES, monthlies)
             LOGGER.info('Monthly Summary populated.')
         except Exception as err:
-            LOGGER.error('Could not populate monthly summary due to: {}.'.format(str(err))) # noqa
+            LOGGER.error(
+                f'Could not populate monthly summary due to: {str(err)}.'
+            )
 
     elif dataset == 'daily':
         try:
             LOGGER.info('Populating daily summary...')
-            stn_dict = get_station_data(cur, station, starting_from)
+            stn_dict = loader.get_station_data(station, starting_from)
             if not (date or station or starting_from):
-                create_index(es_client, 'daily_summary')
-            dailies = generate_daily_data(cur, stn_dict, date)
+                loader.create_index('daily_summary')
+            dailies = loader.generate_daily_data(stn_dict, date)
 
-            util.submit_elastic_package(es_client, dailies)
+            submit_elastic_package(loader.ES, dailies)
             LOGGER.info('Daily Summary populated.')
         except Exception as err:
-            LOGGER.error('Could not populate daily summary due to: {}.'.format(str(err))) # noqa
+            LOGGER.error(
+                f'Could not populate daily summary due to: {str(err)}.'
+            )
 
     else:
-        LOGGER.critical('Unknown dataset parameter {}, skipping index population.'.format(dataset)) # noqa
+        LOGGER.critical(
+            f'Unknown dataset parameter {dataset}, skipping index population.'
+        )
 
     LOGGER.info('Finished populating indices.')
 
-    con.close()
+    loader.con.close()
+
+
+climate_archive.add_command(add)

--- a/msc_pygeoapi/loader/forecast_polygons.py
+++ b/msc_pygeoapi/loader/forecast_polygons.py
@@ -36,6 +36,7 @@ from elasticsearch import helpers, logger as elastic_logger
 from parse import parse
 from gdal import ogr
 
+from msc_pygeoapi import cli_options
 from msc_pygeoapi.env import (
     MSC_PYGEOAPI_ES_TIMEOUT, MSC_PYGEOAPI_ES_URL,
     MSC_PYGEOAPI_ES_AUTH)
@@ -431,13 +432,8 @@ def forecast_polygons():
 
 @click.command()
 @click.pass_context
-@click.option('--file', '-f', 'file_',
-              type=click.Path(exists=True, resolve_path=True),
-              help='Path to file')
-@click.option('--directory', '-d', 'directory',
-              type=click.Path(exists=True, resolve_path=True,
-                              dir_okay=True, file_okay=False),
-              help='Path to directory')
+@cli_options.OPTION_FILE()
+@cli_options.OPTION_DIRECTORY()
 def add(ctx, file_, directory):
     """add data to system"""
 
@@ -468,9 +464,9 @@ def add(ctx, file_, directory):
 
 @click.command()
 @click.pass_context
-@click.option('--index_name', '-i',
-              type=click.Choice(INDICES),
-              help='msc-pygeoapi forecast polygon index name to delete')
+@cli_options.OPTION_INDEX_NAME(
+    type=click.Choice(INDICES),
+)
 def delete_index(ctx, index_name):
     """
     Delete a particular ES index with a given name as argument or all if no

--- a/msc_pygeoapi/loader/hurricanes_realtime.py
+++ b/msc_pygeoapi/loader/hurricanes_realtime.py
@@ -509,7 +509,7 @@ def hurricanes():
                               dir_okay=True, file_okay=False),
               help='Path to directory')
 def add(ctx, file_, directory):
-    """add data to system"""
+    """Add hurricane data to Elasticsearch"""
 
     if all([file_ is None, directory is None]):
         raise click.ClickException('Missing --file/-f or --dir/-d option')

--- a/msc_pygeoapi/loader/hydat.py
+++ b/msc_pygeoapi/loader/hydat.py
@@ -1,3 +1,34 @@
+# =================================================================
+#
+# Author: Etienne Pelletier <etienne.pelletier@canada.ca>
+# Author: Alex Hurka <alex.hurka@canada.ca>
+#
+# Copyright (c) 2020 Etienne Pelletier
+# Copyright (c) 2019 Alex Hurka
+
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
 # Example Usage:
 # python es_loader_hydat.py --db path/to/hydat.sqlite3 --es https://path/to/elasticsearch --username user --password pass --dataset stations # noqa
 '''
@@ -16,7 +47,10 @@ from sqlalchemy.sql import distinct
 from sqlalchemy.schema import MetaData
 from sqlalchemy.orm import sessionmaker
 
-from msc_pygeoapi import util
+from msc_pygeoapi import cli_options
+from msc_pygeoapi.env import MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH
+from msc_pygeoapi.loader.base import BaseLoader
+from msc_pygeoapi.util import get_es, submit_elastic_package
 
 
 LOGGER = logging.getLogger(__name__)
@@ -28,1104 +62,1173 @@ HEADERS = {'Content-type': 'application/json'}
 VERIFY = False
 
 
-def zero_pad(val):
-    """
-    If val is one character long, returns val left padded with a zero.
-    Otherwise, returns the string representation of val.
+class HydatLoader(BaseLoader):
+    """Climat Archive Loader"""
 
-    :param val: the value to be zero-padded.
+    def __init__(self, plugin_def):
+        """initializer"""
 
-    :returns: the value with a leading zero if it is one character,
-              the string representation of the value otherwise.
-    """
-    if len(str(val)) == 1:
-        return '0{}'.format(val)
-    else:
-        return str(val)
+        super().__init__()
 
+        if plugin_def['es_conn_dict']:
+            self.ES = get_es(
+                plugin_def['es_conn_dict']['host'],
+                plugin_def['es_conn_dict']['auth'],
+            )
+        else:
+            self.ES = get_es(MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH)
 
-def create_index(es, index):
-    """
-    Creates the Elasticsearch index named <index>. If the index already
-    exists, it is deleted and re-created. The mappings for the two types
-    are also created.
+        self.db_string = plugin_def['db_string']
 
-    :param es: elasticsearch.Elasticsearch client.
-    :param index: name for the index(es) to be created.
-    """
-    if index == 'observations':
-        mapping =\
-            {
-                "settings": {
-                    "number_of_shards": 1,
-                    "number_of_replicas": 0
-                },
+        self.engine, self.session, self.metadata = self.connect_db()
+
+    def zero_pad(self, val):
+        """
+        If val is one character long, returns val left padded with a zero.
+        Otherwise, returns the string representation of val.
+
+        :param val: the value to be zero-padded.
+
+        :returns: the value with a leading zero if it is one character,
+                the string representation of the value otherwise.
+        """
+        if len(str(val)) == 1:
+            return '0{}'.format(val)
+        else:
+            return str(val)
+
+    def create_index(self, index):
+        """
+        Creates the Elasticsearch index named <index>. If the index already
+        exists, it is deleted and re-created. The mappings for the two types
+        are also created.
+
+        :param es: elasticsearch.Elasticsearch client.
+        :param index: name for the index(es) to be created.
+        """
+        if index == 'observations':
+            mapping = {
+                "settings": {"number_of_shards": 1, "number_of_replicas": 0},
                 "mappings": {
-                    "_meta": {
-                        "geomfields": {
-                            "geometry": "POINT"
-                        }
-                    },
+                    "_meta": {"geomfields": {"geometry": "POINT"}},
                     "properties": {
                         "type": {"type": "text"},
                         "properties": {
                             "properties": {
                                 "STATION_NUMBER": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "IDENTIFIER": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "STATION_NAME": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "PROV_TERR_STATE_LOC": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "LEVEL_SYMBOL_EN": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "LEVEL_SYMBOL_FR": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "DISCHARGE_SYMBOL_EN": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "DISCHARGE_SYMBOL_FR": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "DISCHARGE": {
-                                    "type": "float"
-                                },
-                                "LEVEL": {
-                                    "type": "float"
-                                },
+                                "DISCHARGE": {"type": "float"},
+                                "LEVEL": {"type": "float"},
                                 "DATE": {
                                     "type": "date",
-                                    "format": "yyyy-MM-dd"
-                                }
+                                    "format": "yyyy-MM-dd",
+                                },
                             }
                         },
-                        "geometry": {"type": "geo_shape"}
-                    }
-                }
+                        "geometry": {"type": "geo_shape"},
+                    },
+                },
             }
 
-        index_name = 'hydrometric_daily_mean'
-        if es.indices.exists(index_name):
-            es.indices.delete(index_name)
-            LOGGER.info('Deleted the daily observations index')
-        es.indices.create(index=index_name, body=mapping)
+            index_name = 'hydrometric_daily_mean'
+            if self.ES.indices.exists(index_name):
+                self.ES.indices.delete(index_name)
+                LOGGER.info('Deleted the daily observations index')
+            self.ES.indices.create(index=index_name, body=mapping)
 
-        mapping =\
-            {
-                "settings": {
-                    "number_of_shards": 1,
-                    "number_of_replicas": 0
-                },
+            mapping = {
+                "settings": {"number_of_shards": 1, "number_of_replicas": 0},
                 "mappings": {
-                    "_meta": {
-                        "geomfields": {
-                            "geometry": "POINT"
-                        }
-                    },
+                    "_meta": {"geomfields": {"geometry": "POINT"}},
                     "properties": {
                         "type": {"type": "text"},
                         "properties": {
                             "properties": {
                                 "STATION_NUMBER": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "IDENTIFIER": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "STATION_NAME": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "PROV_TERR_STATE_LOC": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "DATE": {
-                                    "type": "date",
-                                    "format": "yyyy-MM"
-                                },
-                                "MONTHLY_MEAN_DISCHARGE": {
-                                    "type": "float"
-                                },
-                                "MONTHLY_MEAN_LEVEL": {
-                                    "type": "float"
-                                }
+                                "DATE": {"type": "date", "format": "yyyy-MM"},
+                                "MONTHLY_MEAN_DISCHARGE": {"type": "float"},
+                                "MONTHLY_MEAN_LEVEL": {"type": "float"},
                             }
                         },
-                        "geometry": {"type": "geo_shape"}
-                    }
-                }
+                        "geometry": {"type": "geo_shape"},
+                    },
+                },
             }
 
-        index_name = 'hydrometric_monthly_mean'
-        if es.indices.exists(index_name):
-            es.indices.delete(index_name)
-            LOGGER.info('Deleted the monthly observations index')
-        es.indices.create(index=index_name, body=mapping)
+            index_name = 'hydrometric_monthly_mean'
+            if self.ES.indices.exists(index_name):
+                self.ES.indices.delete(index_name)
+                LOGGER.info('Deleted the monthly observations index')
+            self.ES.indices.create(index=index_name, body=mapping)
 
-    if index == 'annual_statistics':
-        mapping =\
-            {
-                "settings": {
-                    "number_of_shards": 1,
-                    "number_of_replicas": 0
-                },
+        if index == 'annual_statistics':
+            mapping = {
+                "settings": {"number_of_shards": 1, "number_of_replicas": 0},
                 "mappings": {
-                    "_meta": {
-                        "geomfields": {
-                            "geometry": "POINT"
-                        }
-                    },
+                    "_meta": {"geomfields": {"geometry": "POINT"}},
                     "properties": {
                         "type": {"type": "text"},
                         "properties": {
                             "properties": {
                                 "STATION_NUMBER": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "IDENTIFIER": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "STATION_NAME": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "PROV_TERR_STATE_LOC": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "MIN_DATE": {
                                     "type": "date",
-                                    "format": "yyyy-MM-dd"
+                                    "format": "yyyy-MM-dd",
                                 },
                                 "MAX_DATE": {
                                     "type": "date",
-                                    "format": "yyyy-MM-dd"
+                                    "format": "yyyy-MM-dd",
                                 },
-                                "MIN_VALUE": {
-                                    "type": "float"
-                                },
-                                "MAX_VALUE": {
-                                    "type": "float"
-                                },
+                                "MIN_VALUE": {"type": "float"},
+                                "MAX_VALUE": {"type": "float"},
                                 "MIN_SYMBOL_EN": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "MIN_SYMBOL_FR": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "MAX_SYMBOL_EN": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "MAX_SYMBOL_FR": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "DATA_TYPE_EN": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "DATA_TYPE_FR": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                }
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
                             }
                         },
-                        "geometry": {"type": "geo_shape"}
-                    }
-                }
+                        "geometry": {"type": "geo_shape"},
+                    },
+                },
             }
 
-        index_name = 'hydrometric_annual_statistics'
-        if es.indices.exists(index_name):
-            es.indices.delete(index_name)
-            LOGGER.info('Deleted the annual statistics index')
-        es.indices.create(index=index_name, body=mapping)
+            index_name = 'hydrometric_annual_statistics'
+            if self.ES.indices.exists(index_name):
+                self.ES.indices.delete(index_name)
+                LOGGER.info('Deleted the annual statistics index')
+            self.ES.indices.create(index=index_name, body=mapping)
 
-    if index == 'stations':
-        mapping =\
-            {
-                "settings": {
-                    "number_of_shards": 1,
-                    "number_of_replicas": 0
-                },
+        if index == 'stations':
+            mapping = {
+                "settings": {"number_of_shards": 1, "number_of_replicas": 0},
                 "mappings": {
-                    "_meta": {
-                        "geomfields": {
-                            "geometry": "POINT"
-                        }
-                    },
+                    "_meta": {"geomfields": {"geometry": "POINT"}},
                     "properties": {
                         "type": {"type": "text"},
                         "properties": {
                             "properties": {
                                 "STATION_NUMBER": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "IDENTIFIER": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "STATION_NAME": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "PROV_TERR_STATE_LOC": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "STATUS_EN": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "STATUS_FR": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "CONTRIBUTOR_EN": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "CONTRIBUTOR_FR": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "VERTICAL_DATUM": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                }
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
                             }
                         },
-                        "geometry": {"type": "geo_shape"}
-                    }
-                }
+                        "geometry": {"type": "geo_shape"},
+                    },
+                },
             }
 
-        index_name = 'hydrometric_stations'
-        if es.indices.exists(index_name):
-            es.indices.delete(index_name)
-            LOGGER.info('Deleted the stations index')
-        es.indices.create(index=index_name, body=mapping)
+            index_name = 'hydrometric_stations'
+            if self.ES.indices.exists(index_name):
+                self.ES.indices.delete(index_name)
+                LOGGER.info('Deleted the stations index')
+            self.ES.indices.create(index=index_name, body=mapping)
 
-    if index == 'annual_peaks':
-        mapping =\
-            {
-                "settings": {
-                    "number_of_shards": 1,
-                    "number_of_replicas": 0
-                },
+        if index == 'annual_peaks':
+            mapping = {
+                "settings": {"number_of_shards": 1, "number_of_replicas": 0},
                 "mappings": {
-                    "_meta": {
-                        "geomfields": {
-                            "geometry": "POINT"
-                        }
-                    },
+                    "_meta": {"geomfields": {"geometry": "POINT"}},
                     "properties": {
                         "type": {"type": "text"},
                         "properties": {
                             "properties": {
                                 "STATION_NUMBER": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "IDENTIFIER": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "STATION_NAME": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "DATE": {
                                     "type": "date",
-                                    "format": "yyyy-MM-dd'T'HH:mm||yyy-MM-dd" # noqa
+                                    "format": "yyyy-MM-dd'T'HH:mm||yyy-MM-dd",
                                 },
                                 "TIMEZONE_OFFSET": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "PROV_TERR_STATE_LOC": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "DATA_TYPE_EN": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "DATA_TYPE_FR": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "PEAK_CODE_EN": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "PEAK_CODE_FR": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "PEAK": {
-                                    "type": "float"
-                                },
+                                "PEAK": {"type": "float"},
                                 "UNITS_EN": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "UNITS_FR": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "SYMBOL_EN": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
+                                    "fields": {"raw": {"type": "keyword"}},
                                 },
                                 "SYMBOL_FR": {
                                     "type": "text",
-                                    "fields": {
-                                        "raw": {"type": "keyword"}
-                                    }
-                                }
+                                    "fields": {"raw": {"type": "keyword"}},
+                                },
                             }
                         },
-                        "geometry": {"type": "geo_shape"}
-                    }
-                }
+                        "geometry": {"type": "geo_shape"},
+                    },
+                },
             }
 
-        index_name = 'hydrometric_annual_peaks'
-        if es.indices.exists(index_name):
-            es.indices.delete(index_name)
-            LOGGER.info('Deleted the annual peaks index')
-        es.indices.create(index=index_name, body=mapping)
+            index_name = 'hydrometric_annual_peaks'
+            if self.ES.indices.exists(index_name):
+                self.ES.indices.delete(index_name)
+                LOGGER.info('Deleted the annual peaks index')
+            self.ES.indices.create(index=index_name, body=mapping)
 
+    def connect_db(self):
+        """
+        Connects to the database.
 
-def connect_db(db_string):
-    """
-    Connects to the database.
+        :param db_string: the connection information for the database.
 
-    :param db_string: the connection information for the database.
+        :returns: a tuple containing the engine, SQLAlchemy session and
+                  metadata.
+        """
 
-    :returns: a tuple containing the engine, SQLAlchemy session and metadata.
-    """
-    LOGGER.info('Connecting to database {}.'.format(db_string))
-    LOGGER.info('Creating engine...')
-    engine = create_engine(db_string)
-    LOGGER.info('Success. Database engine created.')
-    LOGGER.info('Reflecting database schema...')
-    metadata = MetaData()
-    metadata.reflect(bind=engine)
-    LOGGER.info('Success. Schema reflection complete.')
-    LOGGER.info('Establishing session...')
-    Session = sessionmaker(bind=engine)
-    session = Session()
-    LOGGER.info('Success. Database session created.')
-    return (engine, session, metadata)
+        try:
+            LOGGER.info('Connecting to database {}.'.format(self.db_string))
+            LOGGER.info('Creating engine...')
+            engine = create_engine(self.db_string)
+            LOGGER.info('Success. Database engine created.')
+            LOGGER.info('Reflecting database schema...')
+            metadata = MetaData()
+            metadata.reflect(bind=engine)
+            LOGGER.info('Success. Schema reflection complete.')
+            LOGGER.info('Establishing session...')
+            Session = sessionmaker(bind=engine)
+            session = Session()
+            LOGGER.info('Success. Database session created.')
+            return (engine, session, metadata)
+        except Exception as err:
+            LOGGER.critical(
+                f'Could not connect to database due to: {str(err)}. Exiting.'
+            )
+            raise err
 
+    def get_table_var(self, table_name):
+        """
+        Gets table object corresponding to table_name.
 
-def get_table_var(metadata, table_name):
-    """
-    Gets table object corresponding to table_name.
+        :param table_name: the name of the db table to find.
 
-    :param metadata: db metadata returned by connect_db.
-    :param table_name: the name of the db table to find.
+        :returns: the table object if table_name is found, nothing otherwise.
+        """
+        for t in self.metadata.sorted_tables:
+            if t.name == table_name:
+                return t
 
-    :returns: the table object if table_name is found, nothing otherwise.
-    """
-    for t in metadata.sorted_tables:
-        if t.name == table_name:
-            return t
+    def generate_obs(self, station, var, symbol_table, discharge=True):
+        """
+        Generates a list of discharge or level obs for station.
+        Each observation in the list is of the form:
+        {'Station_number' : 'foo', 'Date' : yyyy-MM-dd,
+        'Discharge'/'Level' : 'X'}.
 
+        :param station: the station to generate_obs for.
+        :param var: table object to query discharge or level data from.
+        :param symbol_table: table object to query symbol data from.
+        :param discharge: boolean to determine whether discharge or level
+                        data is returned.
 
-def generate_obs(session, station, var, symbol_table, discharge=True):
-    """
-    Generates a list of discharge or level obs for station.
-    Each observation in the list is of the form:
-    {'Station_number' : 'foo', 'Date' : yyyy-MM-dd, 'Discharge'/'Level' : 'X'}.
-
-    :param session: SQLAlchemy session object.
-    :param station: the station to generate_obs for.
-    :param var: table object to query discharge or level data from.
-    :param symbol_table: table object to query symbol data from.
-    :param discharge: boolean to determine whether discharge or level
-                      data is returned.
-
-    :returns: tuple of lists of dictionaries containing daily obs
-              and monthly means for the station passed in as <station>.
-    """
-    keys = var.columns.keys()
-    symbol_keys = symbol_table.columns.keys()
-    args = {'STATION_NUMBER': station}
-    # get all obs for station
-    obs = session.query(var).filter_by(**args).all()
-    lst = []
-    mean_lst = []
-    if discharge:
-        word_in = 'FLOW'
-        word_out = 'DISCHARGE'
-    else:
-        word_in = 'LEVEL'
-        word_out = 'LEVEL'
-    for row in obs:
+        :returns: tuple of lists of dictionaries containing daily obs
+                and monthly means for the station passed in as <station>.
+        """
+        keys = var.columns.keys()
+        symbol_keys = symbol_table.columns.keys()
+        args = {'STATION_NUMBER': station}
+        # get all obs for station
+        obs = self.session.query(var).filter_by(**args).all()
+        lst = []
+        mean_lst = []
         if discharge:
-            no_days = row[4]
+            word_in = 'FLOW'
+            word_out = 'DISCHARGE'
         else:
-            no_days = row[5]
-        # get a month's worth of obs for station
-        for i in range(1, no_days + 1):
-            insert_dict = {'STATION_NUMBER': row[0], 'DATE': '', word_out: '',
-                           'IDENTIFIER': ''}
-            date = '{}-{}-{}'.format(str(row[1]),
-                                     zero_pad(row[2]),
-                                     zero_pad(i))
-            insert_dict['DATE'] = date
-            insert_dict['IDENTIFIER'] = '{}.{}'.format(row[0], date)
-            value = row[keys.index(word_in.upper() + str(i))]
-            symbol = row[keys.index(word_in.upper() + '_SYMBOL' + str(i))]
-            if symbol is not None and symbol.strip():
-                args = {'SYMBOL_ID': symbol}
-                symbol_data = list(session.query(symbol_table).filter_by(**args).all()[0]) # noqa
+            word_in = 'LEVEL'
+            word_out = 'LEVEL'
+        for row in obs:
+            if discharge:
+                no_days = row[4]
+            else:
+                no_days = row[5]
+            # get a month's worth of obs for station
+            for i in range(1, no_days + 1):
+                insert_dict = {
+                    'STATION_NUMBER': row[0],
+                    'DATE': '',
+                    word_out: '',
+                    'IDENTIFIER': '',
+                }
+                date = '{}-{}-{}'.format(
+                    str(row[1]), self.zero_pad(row[2]), self.zero_pad(i)
+                )
+                insert_dict['DATE'] = date
+                insert_dict['IDENTIFIER'] = '{}.{}'.format(row[0], date)
+                value = row[keys.index(word_in.upper() + str(i))]
+                symbol = row[keys.index(word_in.upper() + '_SYMBOL' + str(i))]
+                if symbol is not None and symbol.strip():
+                    args = {'SYMBOL_ID': symbol}
+                    symbol_data = list(
+                        self.session.query(symbol_table)
+                        .filter_by(**args)
+                        .all()[0]
+                    )
+                    symbol_en = symbol_data[symbol_keys.index('SYMBOL_EN')]
+                    symbol_fr = symbol_data[symbol_keys.index('SYMBOL_FR')]
+                    insert_dict[word_out + '_SYMBOL_EN'] = symbol_en
+                    insert_dict[word_out + '_SYMBOL_FR'] = symbol_fr
+                else:
+                    insert_dict[word_out + '_SYMBOL_EN'] = None
+                    insert_dict[word_out + '_SYMBOL_FR'] = None
+                if value is None:
+                    insert_dict[word_out] = None
+                else:
+                    insert_dict[word_out] = float(value)
+                lst.append(insert_dict)
+                LOGGER.debug(
+                    f'Generated a daily mean value for date '
+                    f'{insert_dict["DATE"]} and station '
+                    f'{insert_dict["STATION_NUMBER"]}'
+                )
+
+                mean_dict = {}
+                date = '{}-{}'.format(str(row[1]), self.zero_pad(row[2]))
+                mean_dict['DATE'] = date
+                mean_dict['IDENTIFIER'] = '{}.{}'.format(row[0], date)
+
+                if row[keys.index('MONTHLY_MEAN')]:
+                    mean_dict['MONTHLY_MEAN_' + word_out] = float(
+                        row[keys.index('MONTHLY_MEAN')]
+                    )
+                else:
+                    mean_dict['MONTHLY_MEAN_' + word_out] = None
+                mean_lst.append(mean_dict)
+                LOGGER.debug(
+                    f'Generated a monthly mean value for date '
+                    f'{mean_dict["DATE"]} and station '
+                    f'{insert_dict["STATION_NUMBER"]}'
+                )
+        return (lst, mean_lst)
+
+    def generate_means(
+        self, discharge_var, level_var, station_table, symbol_table
+    ):
+        """
+        Unpivots db observations one station at a time, and reformats
+        observations so they can be bulk inserted to Elasticsearch.
+
+        Returns a generator of dictionaries that represent upsert actions
+        into Elasticsearch's bulk API.
+
+        Generates documents for both daily and monthly means indexes.
+
+        :param discharge_var: table object to query discharge data from.
+        :param level_var: table object to query level data from.
+        :param station_table: table object to query station data from.
+        :param symbol_table: table object to query symbol data from.
+        :returns: generator of bulk API upsert actions.
+        """
+        discharge_station_codes = [
+            x[0]
+            for x in self.session.query(
+                distinct(discharge_var.c['STATION_NUMBER'])
+            ).all()
+        ]
+        level_station_codes = [
+            x[0]
+            for x in self.session.query(
+                distinct(level_var.c['STATION_NUMBER'])
+            ).all()
+        ]
+        station_codes = list(
+            set(discharge_station_codes).union(level_station_codes)
+        )
+        for station in station_codes:
+            LOGGER.debug(
+                'Generating discharge and level values for station {}'.format(
+                    station
+                )
+            )
+            discharge_lst, discharge_means = self.generate_obs(
+                self.session, station, discharge_var, symbol_table, True
+            )
+            level_lst, level_means = self.generate_obs(
+                station, level_var, symbol_table, False
+            )
+            station_keys = station_table.columns.keys()
+            args = {'STATION_NUMBER': station}
+            # Gather station metadata from the stations table.
+            station_metadata = list(
+                self.session.query(station_table).filter_by(**args).all()[0]
+            )
+            station_name = station_metadata[station_keys.index('STATION_NAME')]
+            province = station_metadata[
+                station_keys.index('PROV_TERR_STATE_LOC')
+            ]
+            station_coords = [
+                float(station_metadata[station_keys.index('LONGITUDE')]),
+                float(station_metadata[station_keys.index('LATITUDE')]),
+            ]
+            # combine dictionaries with dates in common
+            d = defaultdict(dict)
+            for el in (discharge_lst, level_lst):
+                for elem in el:
+                    d[elem['DATE']].update(elem)
+            comb_list = d.values()
+            # add missing discharge/level key to any dicts that were
+            # not combined (i.e. full outer join)
+            for item in comb_list:
+                if 'LEVEL' not in item:
+                    item['LEVEL'] = None
+                    item['LEVEL_SYMBOL_EN'] = None
+                    item['LEVEL_SYMBOL_FR'] = None
+                if 'DISCHARGE' not in item:
+                    item['DISCHARGE'] = None
+                    item['DISCHARGE_SYMBOL_EN'] = None
+                    item['DISCHARGE_SYMBOL_FR'] = None
+                wrapper = {
+                    'type': 'Feature',
+                    'properties': item,
+                    'geometry': {'type': 'Point'},
+                }
+                wrapper['properties']['STATION_NAME'] = station_name
+                wrapper['properties']['PROV_TERR_STATE_LOC'] = province
+                wrapper['geometry']['coordinates'] = station_coords
+                action = {
+                    '_id': item['IDENTIFIER'],
+                    '_index': 'hydrometric_daily_mean',
+                    '_op_type': 'update',
+                    'doc': wrapper,
+                    'doc_as_upsert': True,
+                }
+                yield action
+
+            # Insert all monthly means for this station
+            d = defaultdict(dict)
+            for el in (discharge_means, level_means):
+                for elem in el:
+                    d[elem['DATE']].update(elem)
+            comb_list = d.values()
+            # add missing mean discharge/level key to any dicts that were
+            # not combined (i.e. full outer join)
+            for item in comb_list:
+                if 'MONTHLY_MEAN_LEVEL' not in item:
+                    item['MONTHLY_MEAN_LEVEL'] = None
+                if 'MONTHLY_MEAN_DISCHARGE' not in item:
+                    item['MONTHLY_MEAN_DISCHARGE'] = None
+                wrapper = {
+                    'type': 'Feature',
+                    'properties': item,
+                    'geometry': {'type': 'Point'},
+                }
+                wrapper['properties']['STATION_NAME'] = station_name
+                wrapper['properties']['STATION_NUMBER'] = station
+                wrapper['properties']['PROV_TERR_STATE_LOC'] = province
+                wrapper['geometry']['coordinates'] = station_coords
+                action = {
+                    '_id': item['IDENTIFIER'],
+                    '_index': 'hydrometric_monthly_mean',
+                    '_op_type': 'update',
+                    'doc': wrapper,
+                    'doc_as_upsert': True,
+                }
+                yield action
+
+    def generate_stations(self, station_table):
+        """
+        Queries station data from the db, and reformats
+        data so it can be inserted into Elasticsearch.
+
+        Returns a generator of dictionaries that represent upsert actions
+        into Elasticsearch's bulk API.
+
+        :param station_table: table object to query station data from.
+        :returns: generator of bulk API upsert actions.
+        """
+
+        url = 'https://api.geo.weather.gc.ca'
+
+        station_codes = [
+            x[0]
+            for x in self.session.query(
+                distinct(station_table.c['STATION_NUMBER'])
+            ).all()
+        ]
+        for station in station_codes:
+            station_keys = station_table.columns.keys()
+            args = {'STATION_NUMBER': station}
+            # Gather station metadata from the stations table.
+            station_metadata = list(
+                self.session.query(station_table).filter_by(**args).all()[0]
+            )
+            station_name = station_metadata[station_keys.index('STATION_NAME')]
+            station_loc = station_metadata[
+                station_keys.index('PROV_TERR_STATE_LOC')
+            ]
+            station_status = station_metadata[station_keys.index('HYD_STATUS')]
+            station_coords = [
+                float(station_metadata[station_keys.index('LONGITUDE')]),
+                float(station_metadata[station_keys.index('LATITUDE')]),
+            ]
+            agency_id = station_metadata[station_keys.index('CONTRIBUTOR_ID')]
+            datum_id = station_metadata[station_keys.index('DATUM_ID')]
+            if agency_id is not None:
+                agency_args = {'AGENCY_ID': agency_id}
+                agency_table = self.get_table_var('AGENCY_LIST')
+                agency_keys = agency_table.columns.keys()
+                agency_metadata = list(
+                    self.session.query(agency_table)
+                    .filter_by(**agency_args)
+                    .all()[0]
+                )
+                agency_en = agency_metadata[agency_keys.index('AGENCY_EN')]
+                agency_fr = agency_metadata[agency_keys.index('AGENCY_FR')]
+            else:
+                agency_en = agency_fr = ''
+                LOGGER.warning(
+                    'Could not find agency information for station {}'.format(
+                        station
+                    )
+                )
+            if datum_id is not None:
+                datum_args = {'DATUM_ID': datum_id}
+                datum_table = self.get_table_var('DATUM_LIST')
+                datum_keys = datum_table.columns.keys()
+                datum_metadata = list(
+                    self.session.query(datum_table)
+                    .filter_by(**datum_args)
+                    .all()[0]
+                )
+                datum_en = datum_metadata[datum_keys.index('DATUM_EN')]
+            else:
+                datum_en = ''
+                LOGGER.warning(
+                    'Could not find datum information for station {}'.format(
+                        station
+                    )
+                )
+            if station_status is not None:
+                status_args = {'STATUS_CODE': station_status}
+                status_table = self.get_table_var('STN_STATUS_CODES')
+                status_keys = status_table.columns.keys()
+                status_metadata = list(
+                    self.session.query(status_table)
+                    .filter_by(**status_args)
+                    .all()[0]
+                )
+                status_en = status_metadata[status_keys.index('STATUS_EN')]
+                status_fr = status_metadata[status_keys.index('STATUS_FR')]
+            else:
+                status_en = status_fr = ''
+                LOGGER.warning(
+                    'Could not find status information for station {}'.format(
+                        station
+                    )
+                )
+
+            insert_dict = {
+                'type': 'Feature',
+                'properties': {
+                    'STATION_NAME': station_name,
+                    'IDENTIFIER': station,
+                    'STATION_NUMBER': station,
+                    'PROV_TERR_STATE_LOC': station_loc,
+                    'STATUS_EN': status_en,
+                    'STATUS_FR': status_fr,
+                    'CONTRIBUTOR_EN': agency_en,
+                    'CONTRIBUTOR_FR': agency_fr,
+                    'VERTICAL_DATUM': datum_en,
+                    'links': [
+                        {
+                            'type': 'text/html',
+                            'rel': 'related',
+                            'title': f'Station Information for {station_name} ({station})',  # noqa
+                            'href': f'{url}/collections/hydrometric-stations/items?STATION_NUMBER={station}&f=html',  # noqa
+                        },
+                        {
+                            'type': 'application/json',
+                            'rel': 'related',
+                            'title': f'Daily Mean of Water Level or Discharge for {station_name} ({station})',  # noqa
+                            'href': f'{url}/collections/hydrometric-daily-mean/items?STATION_NUMBER={station}',  # noqa
+                        },
+                        {
+                            'type': 'application/json',
+                            'rel': 'related',
+                            'title': f'Monthly Mean of Water Level or Discharge for {station_name} ({station})',  # noqa
+                            'href': f'{url}/collections/hydrometric-monthly-mean/items?STATION_NUMBER={station}',  # noqa
+                        },
+                        {
+                            'type': 'application/json',
+                            'rel': 'related',
+                            'title': f'Annual Maximum and Minimum Instantaneous Water Level or Discharge for {station_name} ({station})',  # noqa
+                            'href': f'{url}/collections/hydrometric-annual-peaks/items?STATION_NUMBER={station}',  # noqa
+                        },
+                        {
+                            'type': 'application/json',
+                            'rel': 'related',
+                            'title': f'Annual Maximum and Minimum Daily Water Level or Discharge for {station_name} ({station})',  # noqa
+                            'href': f'{url}/collections/hydrometric-annual-statistics/items?STATION_NUMBER={station}',  # noqa
+                        },
+                        {
+                            'type': 'text/html',
+                            'rel': 'alternate',
+                            'title': 'Station Information for {} ({})'.format(
+                                station_name, station
+                            ),
+                            'href': f'https://wateroffice.ec.gc.ca/report/historical_e.html?stn={station}',  # noqa
+                            'hreflang': 'en-CA',
+                        },
+                        {
+                            'type': 'text/html',
+                            'rel': 'alternate',
+                            'title': f'Informations pour la station {station_name} ({station})',  # noqa
+                            'href': f'https://wateroffice.ec.gc.ca/report/historical_f.html?stn={station}',  # noqa
+                            'hreflang': 'fr-CA',
+                        },
+                    ],
+                },
+                'geometry': {'type': 'Point', 'coordinates': station_coords},
+            }
+
+            action = {
+                '_id': station,
+                '_index': 'hydrometric_stations',
+                '_op_type': 'update',
+                'doc': insert_dict,
+                'doc_as_upsert': True,
+            }
+            yield action
+
+    def generate_annual_stats(
+        self, annual_stats_table, data_types_table, station_table, symbol_table
+    ):
+        """
+        Queries annual statistics data from the db, and reformats
+        data so it can be inserted into Elasticsearch.
+
+        Returns a generator of dictionaries that represent upsert actions
+        into Elasticsearch's bulk API.
+
+        :param session: SQLAlchemy session object.
+        :param annual_stats_table: table object to query annual stats data
+                                   from.
+        :param data_types_table: table object to query data types data from.
+        :param station_table: table object to query station data from.
+        :param symbol_table: table object to query symbol data from.
+        :returns: generator of bulk API upsert actions.
+        """
+        results = (
+            self.session.query(annual_stats_table)
+            .group_by(
+                annual_stats_table.c['STATION_NUMBER'],
+                annual_stats_table.c['DATA_TYPE'],
+                annual_stats_table.c['YEAR'],
+            )
+            .all()
+        )
+        results = [list(x) for x in results]
+        annual_stats_keys = annual_stats_table.columns.keys()
+        station_keys = station_table.columns.keys()
+        data_types_keys = data_types_table.columns.keys()
+        for result in results:
+            station_number = result[annual_stats_keys.index('STATION_NUMBER')]
+            data_type = result[annual_stats_keys.index('DATA_TYPE')]
+            year = result[annual_stats_keys.index('YEAR')]
+            min_month = result[annual_stats_keys.index('MIN_MONTH')]
+            min_day = result[annual_stats_keys.index('MIN_DAY')]
+            min_value = result[annual_stats_keys.index('MIN')]
+            min_symbol = result[annual_stats_keys.index('MIN_SYMBOL')]
+            max_month = result[annual_stats_keys.index('MAX_MONTH')]
+            max_day = result[annual_stats_keys.index('MAX_DAY')]
+            max_value = result[annual_stats_keys.index('MAX')]
+            max_symbol = result[annual_stats_keys.index('MAX_SYMBOL')]
+            args = {'STATION_NUMBER': station_number}
+            station_metadata = list(
+                self.session.query(station_table).filter_by(**args).all()[0]
+            )
+            args = {'DATA_TYPE': data_type}
+            data_type_metadata = list(
+                self.session.query(data_types_table).filter_by(**args).all()[0]
+            )
+            station_name = station_metadata[station_keys.index('STATION_NAME')]
+            province = station_metadata[
+                station_keys.index('PROV_TERR_STATE_LOC')
+            ]
+            station_coords = [
+                float(station_metadata[station_keys.index('LONGITUDE')]),
+                float(station_metadata[station_keys.index('LATITUDE')]),
+            ]
+            data_type_en = data_type_metadata[
+                data_types_keys.index('DATA_TYPE_EN')
+            ]
+            data_type_fr = data_type_metadata[
+                data_types_keys.index('DATA_TYPE_FR')
+            ]
+            if data_type_en == 'Flow':
+                data_type_en = 'Discharge'
+            if min_month is None or min_day is None:
+                min_date = None
+                LOGGER.warning(
+                    f'Could not find min date for station {station_number}'
+                )
+            else:
+                min_date = '{}-{}-{}'.format(
+                    year, self.zero_pad(min_month), self.zero_pad(min_day)
+                )
+            if max_month is None or max_day is None:
+                max_date = None
+                LOGGER.warning(
+                    f'Could not find max date for station {station_number}'
+                )
+            else:
+                max_date = '{}-{}-{}'.format(
+                    year, self.zero_pad(max_month), self.zero_pad(max_day)
+                )
+            symbol_keys = symbol_table.columns.keys()
+            if min_symbol is not None and min_symbol.strip():
+                args = {'SYMBOL_ID': min_symbol}
+                symbol_data = list(
+                    self.session.query(symbol_table).filter_by(**args).all()[0]
+                )
+                min_symbol_en = symbol_data[symbol_keys.index('SYMBOL_EN')]
+                min_symbol_fr = symbol_data[symbol_keys.index('SYMBOL_FR')]
+            else:
+                min_symbol_en = min_symbol_fr = ''
+                LOGGER.warning(
+                    f'Could not find min symbol for station {station_number}'
+                )
+            if max_symbol is not None and max_symbol.strip():
+                args = {'SYMBOL_ID': max_symbol}
+                symbol_data = list(
+                    self.session.query(symbol_table).filter_by(**args).all()[0]
+                )
+                max_symbol_en = symbol_data[symbol_keys.index('SYMBOL_EN')]
+                max_symbol_fr = symbol_data[symbol_keys.index('SYMBOL_FR')]
+            else:
+                max_symbol_en = max_symbol_fr = ''
+                LOGGER.warning(
+                    f'Could not find max symbol for station {station_number}'
+                )
+            if data_type_en == 'Water Level':
+                es_id = '{}.{}.level-niveaux'.format(station_number, year)
+            elif data_type_en == 'Discharge':
+                es_id = '{}.{}.discharge-debit'.format(station_number, year)
+            elif data_type_en == 'Sediment in mg/L':
+                es_id = '{}.{}.sediment-sediment'.format(station_number, year)
+            elif data_type_en == 'Daily Mean Tonnes':
+                es_id = '{}.{}.tonnes-tonnes'.format(station_number, year)
+            else:
+                es_id = '{}.{}.None'.format(station_number, year)
+            insert_dict = {
+                'type': 'Feature',
+                'properties': {
+                    'STATION_NAME': station_name,
+                    'IDENTIFIER': es_id,
+                    'STATION_NUMBER': station_number,
+                    'PROV_TERR_STATE_LOC': province,
+                    'DATA_TYPE_EN': data_type_en,
+                    'DATA_TYPE_FR': data_type_fr,
+                    'MIN_DATE': min_date,
+                    'MIN_VALUE': float(min_value) if min_value else None,
+                    'MIN_SYMBOL_EN': min_symbol_en,
+                    'MIN_SYMBOL_FR': min_symbol_fr,
+                    'MAX_DATE': max_date,
+                    'MAX_VALUE': float(max_value) if max_value else None,
+                    'MAX_SYMBOL_EN': max_symbol_en,
+                    'MAX_SYMBOL_FR': max_symbol_fr,
+                },
+                'geometry': {'type': 'Point', 'coordinates': station_coords},
+            }
+            action = {
+                '_id': es_id,
+                '_index': 'hydrometric_annual_statistics',
+                '_op_type': 'update',
+                'doc': insert_dict,
+                'doc_as_upsert': True,
+            }
+            yield action
+
+    def generate_annual_peaks(
+        self,
+        annual_peaks_table,
+        data_types_table,
+        symbol_table,
+        station_table,
+    ):
+        """
+        Queries annual peaks data from the db, and reformats
+        data so it can be inserted into Elasticsearch.
+
+        Returns a generator of dictionaries that represent upsert actions
+        into Elasticsearch's bulk API.
+
+        :param annual_peaks_table: table object to query annual peaks data
+                                   from.
+        :param data_types_table: table object to query data types data from.
+        :param symbol_table: table object to query symbol data from.
+        :param station_table: table object to query station data from.
+        :returns: generator of bulk API upsert actions.
+        """
+        tz_map = {
+            None: None,
+            '*': None,
+            '0': None,
+            'AKST': '-9',
+            'AST': '-4',
+            'CST': '-6',
+            'EST': '-5',
+            'MDT': '-6',
+            'MST': '-7',
+            'NST': '-3.5',
+            'PST': '-8',
+            'YST': '-9',
+        }
+        annual_peaks_keys = annual_peaks_table.columns.keys()
+        station_keys = station_table.columns.keys()
+        data_types_keys = data_types_table.columns.keys()
+        results = (
+            self.session.query(annual_peaks_table)
+            .group_by(
+                annual_peaks_table.c['STATION_NUMBER'],
+                annual_peaks_table.c['DATA_TYPE'],
+                annual_peaks_table.c['YEAR'],
+                annual_peaks_table.c['PEAK_CODE'],
+            )
+            .all()
+        )
+        results = [list(x) for x in results]
+        for result in results:
+            station_number = result[annual_peaks_keys.index('STATION_NUMBER')]
+            data_type = result[annual_peaks_keys.index('DATA_TYPE')]
+            year = result[annual_peaks_keys.index('YEAR')]
+            peak_id = result[annual_peaks_keys.index('PEAK_CODE')]
+            unit_id = result[annual_peaks_keys.index('PRECISION_CODE')]
+            month = result[annual_peaks_keys.index('MONTH')]
+            day = result[annual_peaks_keys.index('DAY')]
+            hour = result[annual_peaks_keys.index('HOUR')]
+            minute = result[annual_peaks_keys.index('MINUTE')]
+            time_zone = tz_map[result[annual_peaks_keys.index('TIME_ZONE')]]
+            peak_value = result[annual_peaks_keys.index('PEAK')]
+            symbol_id = result[annual_peaks_keys.index('SYMBOL')]
+            if month is None or day is None:
+                date = None
+                LOGGER.warning(
+                    f'Could not find date for station {station_number}'
+                )
+            elif hour is None or minute is None:
+                date = '{}-{}-{}'.format(
+                    year, self.zero_pad(month), self.zero_pad(day)
+                )
+            else:
+                date = '{}-{}-{}T{}:{}'.format(
+                    year,
+                    self.zero_pad(month),
+                    self.zero_pad(day),
+                    self.zero_pad(hour),
+                    self.zero_pad(minute),
+                )
+            args = {'STATION_NUMBER': station_number}
+            try:
+                station_metadata = list(
+                    self.session.query(station_table)
+                    .filter_by(**args)
+                    .all()[0]
+                )
+                station_name = station_metadata[
+                    station_keys.index('STATION_NAME')
+                ]
+                province = station_metadata[
+                    station_keys.index('PROV_TERR_STATE_LOC')
+                ]
+                station_coords = [
+                    float(station_metadata[station_keys.index('LONGITUDE')]),
+                    float(station_metadata[station_keys.index('LATITUDE')]),
+                ]
+            except Exception:
+                station_name = None
+                province = None
+                station_coords = [None, None]
+                LOGGER.warning(
+                    f'Could not find station information for station '
+                    f'{station_number}'
+                )
+            args = {'DATA_TYPE': data_type}
+            data_type_metadata = list(
+                self.session.query(data_types_table).filter_by(**args).all()[0]
+            )
+            data_type_en = data_type_metadata[
+                data_types_keys.index('DATA_TYPE_EN')
+            ]
+            data_type_fr = data_type_metadata[
+                data_types_keys.index('DATA_TYPE_FR')
+            ]
+            if data_type_en == 'Flow':
+                data_type_en = 'Discharge'
+            if unit_id:
+                unit_codes = self.get_table_var('PRECISION_CODES')
+                unit_keys = unit_codes.columns.keys()
+                args = {'PRECISION_CODE': unit_id}
+                unit_data = list(
+                    self.session.query(unit_codes).filter_by(**args).all()[0]
+                )
+                unit_en = unit_data[unit_keys.index('PRECISION_EN')]
+                unit_fr = unit_data[unit_keys.index('PRECISION_FR')]
+            else:
+                unit_en = unit_fr = None
+                LOGGER.warning(
+                    'Could not find units for station {}'.format(
+                        station_number
+                    )
+                )
+            if peak_id:
+                peak_codes = self.get_table_var('PEAK_CODES')
+                peak_keys = peak_codes.columns.keys()
+                args = {'PEAK_CODE': peak_id}
+                peak_data = list(
+                    self.session.query(peak_codes).filter_by(**args).all()[0]
+                )
+                peak_en = peak_data[peak_keys.index('PEAK_EN')]
+                peak_fr = peak_data[peak_keys.index('PEAK_FR')]
+            else:
+                peak_en = peak_fr = None
+                LOGGER.warning(
+                    f'Could not find peaks for station {station_number}'
+                )
+            if symbol_id and symbol_id.strip():
+                symbol_keys = symbol_table.columns.keys()
+                args = {'SYMBOL_ID': symbol_id}
+                symbol_data = list(
+                    self.session.query(symbol_table).filter_by(**args).all()[0]
+                )
                 symbol_en = symbol_data[symbol_keys.index('SYMBOL_EN')]
                 symbol_fr = symbol_data[symbol_keys.index('SYMBOL_FR')]
-                insert_dict[word_out + '_SYMBOL_EN'] = symbol_en
-                insert_dict[word_out + '_SYMBOL_FR'] = symbol_fr
             else:
-                insert_dict[word_out + '_SYMBOL_EN'] = None
-                insert_dict[word_out + '_SYMBOL_FR'] = None
-            if value is None:
-                insert_dict[word_out] = None
+                symbol_en = symbol_fr = None
+                LOGGER.warning(
+                    f'Could not find symbol for station {station_number}'
+                )
+            if peak_en == 'Maximum':
+                peak = 'maximum-maximale'
+            elif peak_en == 'Minimum':
+                peak = 'minimum-minimale'
             else:
-                insert_dict[word_out] = float(value)
-            lst.append(insert_dict)
-            LOGGER.debug('Generated a daily mean value for date {} and station {}'.format(insert_dict['DATE'], insert_dict['STATION_NUMBER'])) # noqa
+                peak = None
 
-            mean_dict = {}
-            date = '{}-{}'.format(str(row[1]),
-                                  zero_pad(row[2]))
-            mean_dict['DATE'] = date
-            mean_dict['IDENTIFIER'] = '{}.{}'.format(row[0], date)
-
-            if row[keys.index('MONTHLY_MEAN')]:
-                mean_dict['MONTHLY_MEAN_' + word_out] = float(row[keys.index('MONTHLY_MEAN')]) # noqa
+            if data_type_en == 'Water Level':
+                es_id = '{}.{}.level-niveaux.{}'.format(
+                    station_number, year, peak
+                )
+            elif data_type_en == 'Discharge':
+                es_id = '{}.{}.discharge-debit.{}'.format(
+                    station_number, year, peak
+                )
+            elif data_type_en == 'Sediment in mg/L':
+                es_id = '{}.{}.sediment-sediment.{}'.format(
+                    station_number, year, peak
+                )
+            elif data_type_en == 'Daily Mean Tonnes':
+                es_id = '{}.{}.tonnes-tonnes.{}'.format(
+                    station_number, year, peak
+                )
             else:
-                mean_dict['MONTHLY_MEAN_' + word_out] = None
-            mean_lst.append(mean_dict)
-            LOGGER.debug('Generated a monthly mean value for date {} and station {}'.format(mean_dict['DATE'], insert_dict['STATION_NUMBER'])) # noqa
-    return (lst, mean_lst)
-
-
-def generate_means(session, discharge_var, level_var,
-                   station_table, symbol_table):
-    """
-    Unpivots db observations one station at a time, and reformats
-    observations so they can be bulk inserted to Elasticsearch.
-
-    Returns a generator of dictionaries that represent upsert actions
-    into Elasticsearch's bulk API.
-
-    Generates documents for both daily and monthly means indexes.
-
-    :param session: SQLAlchemy session object.
-    :param discharge_var: table object to query discharge data from.
-    :param level_var: table object to query level data from.
-    :param station_table: table object to query station data from.
-    :param symbol_table: table object to query symbol data from.
-    :returns: generator of bulk API upsert actions.
-    """
-    discharge_station_codes = [x[0] for x in session.query(distinct(discharge_var.c['STATION_NUMBER'])).all()] # noqa
-    level_station_codes = [x[0] for x in session.query(distinct(level_var.c['STATION_NUMBER'])).all()] # noqa
-    station_codes = list(set(discharge_station_codes).union(level_station_codes)) # noqa
-    for station in station_codes:
-        LOGGER.debug('Generating discharge and level values for station {}'.format(station)) # noqa
-        discharge_lst, discharge_means = \
-            generate_obs(session, station, discharge_var, symbol_table, True)
-        level_lst, level_means = generate_obs(session, station, level_var,
-                                              symbol_table, False)
-        station_keys = station_table.columns.keys()
-        args = {'STATION_NUMBER': station}
-        # Gather station metadata from the stations table.
-        station_metadata = list(session.query(station_table).filter_by(**args).all()[0]) # noqa
-        station_name = station_metadata[station_keys.index('STATION_NAME')]
-        province = station_metadata[station_keys.index('PROV_TERR_STATE_LOC')]
-        station_coords = [float(station_metadata[station_keys.index('LONGITUDE')]), # noqa
-                          float(station_metadata[station_keys.index('LATITUDE')])] # noqa
-        # combine dictionaries with dates in common
-        d = defaultdict(dict)
-        for el in (discharge_lst, level_lst):
-            for elem in el:
-                d[elem['DATE']].update(elem)
-        comb_list = d.values()
-        # add missing discharge/level key to any dicts that were
-        # not combined (i.e. full outer join)
-        for item in comb_list:
-            if 'LEVEL' not in item:
-                item['LEVEL'] = None
-                item['LEVEL_SYMBOL_EN'] = None
-                item['LEVEL_SYMBOL_FR'] = None
-            if 'DISCHARGE' not in item:
-                item['DISCHARGE'] = None
-                item['DISCHARGE_SYMBOL_EN'] = None
-                item['DISCHARGE_SYMBOL_FR'] = None
-            wrapper = {'type': 'Feature', 'properties': item,
-                       'geometry': {'type': 'Point'}}
-            wrapper['properties']['STATION_NAME'] = station_name
-            wrapper['properties']['PROV_TERR_STATE_LOC'] = province
-            wrapper['geometry']['coordinates'] = station_coords
-            action = {
-                '_id': item['IDENTIFIER'],
-                '_index': 'hydrometric_daily_mean',
-                '_op_type': 'update',
-                'doc': wrapper,
-                'doc_as_upsert': True
+                es_id = '{}.{}.None'.format(station_number, year)
+            insert_dict = {
+                'type': 'Feature',
+                'properties': {
+                    'STATION_NAME': station_name,
+                    'STATION_NUMBER': station_number,
+                    'PROV_TERR_STATE_LOC': province,
+                    'IDENTIFIER': es_id,
+                    'DATA_TYPE_EN': data_type_en,
+                    'DATA_TYPE_FR': data_type_fr,
+                    'DATE': date,
+                    'TIMEZONE_OFFSET': time_zone,
+                    'PEAK_CODE_EN': peak_en,
+                    'PEAK_CODE_FR': peak_fr,
+                    'PEAK': peak_value,
+                    'UNITS_EN': unit_en,
+                    'UNITS_FR': unit_fr,
+                    'SYMBOL_EN': symbol_en,
+                    'SYMBOL_FR': symbol_fr,
+                },
+                'geometry': {'type': 'Point', 'coordinates': station_coords},
             }
-            yield action
-
-        # Insert all monthly means for this station
-        d = defaultdict(dict)
-        for el in (discharge_means, level_means):
-            for elem in el:
-                d[elem['DATE']].update(elem)
-        comb_list = d.values()
-        # add missing mean discharge/level key to any dicts that were
-        # not combined (i.e. full outer join)
-        for item in comb_list:
-            if 'MONTHLY_MEAN_LEVEL' not in item:
-                item['MONTHLY_MEAN_LEVEL'] = None
-            if 'MONTHLY_MEAN_DISCHARGE' not in item:
-                item['MONTHLY_MEAN_DISCHARGE'] = None
-            wrapper = {'type': 'Feature', 'properties': item,
-                       'geometry': {'type': 'Point'}}
-            wrapper['properties']['STATION_NAME'] = station_name
-            wrapper['properties']['STATION_NUMBER'] = station
-            wrapper['properties']['PROV_TERR_STATE_LOC'] = province
-            wrapper['geometry']['coordinates'] = station_coords
             action = {
-                '_id': item['IDENTIFIER'],
-                '_index': 'hydrometric_monthly_mean',
+                '_id': es_id,
+                '_index': 'hydrometric_annual_peaks',
                 '_op_type': 'update',
-                'doc': wrapper,
-                'doc_as_upsert': True
+                'doc': insert_dict,
+                'doc_as_upsert': True,
             }
             yield action
 
 
-def generate_stations(session, metadata, path, station_table):
-    """
-    Queries station data from the db, and reformats
-    data so it can be inserted into Elasticsearch.
-
-    Returns a generator of dictionaries that represent upsert actions
-    into Elasticsearch's bulk API.
-
-    :param session: SQLAlchemy session object.
-    :param metadata: db metadata returned by connect_db.
-    :param path: URL to Elasticsearch.
-    :param station_table: table object to query station data from.
-    :returns: generator of bulk API upsert actions.
-    """
-
-    url = 'https://api.geo.weather.gc.ca'
-
-    station_codes = [x[0] for x in session.query(distinct(station_table.c['STATION_NUMBER'])).all()] # noqa
-    for station in station_codes:
-        station_keys = station_table.columns.keys()
-        args = {'STATION_NUMBER': station}
-        # Gather station metadata from the stations table.
-        station_metadata = list(session.query(station_table).filter_by(**args).all()[0]) # noqa
-        station_name = station_metadata[station_keys.index('STATION_NAME')]
-        station_loc = station_metadata[station_keys.index('PROV_TERR_STATE_LOC')] # noqa
-        station_status = station_metadata[station_keys.index('HYD_STATUS')]
-        station_coords = [float(station_metadata[station_keys.index('LONGITUDE')]), # noqa
-                          float(station_metadata[station_keys.index('LATITUDE')])] # noqa
-        agency_id = station_metadata[station_keys.index('CONTRIBUTOR_ID')]
-        datum_id = station_metadata[station_keys.index('DATUM_ID')]
-        if agency_id is not None:
-            agency_args = {'AGENCY_ID': agency_id}
-            agency_table = get_table_var(metadata, 'AGENCY_LIST')
-            agency_keys = agency_table.columns.keys()
-            agency_metadata = list(session.query(agency_table).filter_by(**agency_args).all()[0]) # noqa
-            agency_en = agency_metadata[agency_keys.index('AGENCY_EN')]
-            agency_fr = agency_metadata[agency_keys.index('AGENCY_FR')]
-        else:
-            agency_en = agency_fr = ''
-            LOGGER.warning('Could not find agency information for station {}'.format(station)) # noqa
-        if datum_id is not None:
-            datum_args = {'DATUM_ID': datum_id}
-            datum_table = get_table_var(metadata, 'DATUM_LIST')
-            datum_keys = datum_table.columns.keys()
-            datum_metadata = list(session.query(datum_table).filter_by(**datum_args).all()[0]) # noqa
-            datum_en = datum_metadata[datum_keys.index('DATUM_EN')]
-        else:
-            datum_en = ''
-            LOGGER.warning('Could not find datum information for station {}'.format(station)) # noqa
-        if station_status is not None:
-            status_args = {'STATUS_CODE': station_status}
-            status_table = get_table_var(metadata, 'STN_STATUS_CODES')
-            status_keys = status_table.columns.keys()
-            status_metadata = list(session.query(status_table).filter_by(**status_args).all()[0]) # noqa
-            status_en = status_metadata[status_keys.index('STATUS_EN')]
-            status_fr = status_metadata[status_keys.index('STATUS_FR')]
-        else:
-            status_en = status_fr = ''
-            LOGGER.warning('Could not find status information for station {}'.format(station)) # noqa
-
-        insert_dict = {
-            'type': 'Feature',
-            'properties': {
-                'STATION_NAME': station_name,
-                'IDENTIFIER': station,
-                'STATION_NUMBER': station,
-                'PROV_TERR_STATE_LOC': station_loc,
-                'STATUS_EN': status_en,
-                'STATUS_FR': status_fr,
-                'CONTRIBUTOR_EN': agency_en,
-                'CONTRIBUTOR_FR': agency_fr,
-                'VERTICAL_DATUM': datum_en,
-                'links': [{
-                    'type': 'text/html',
-                    'rel': 'related',
-                    'title': 'Station Information for {} ({})'.format(
-                        station_name, station),
-                    'href': '{}/collections/hydrometric-stations/items?STATION_NUMBER={}&f=html'.format(url, station)  # noqa
-                }, {
-                    'type': 'application/json',
-                    'rel': 'related',
-                    'title': 'Daily Mean of Water Level or Discharge for {} ({})'.format(  # noqa
-                        station_name, station),
-                    'href': '{}/collections/hydrometric-daily-mean/items?STATION_NUMBER={}'.format(url, station)  # noqa
-                }, {
-                    'type': 'application/json',
-                    'rel': 'related',
-                    'title': 'Monthly Mean of Water Level or Discharge for {} ({})'.format(  # noqa
-                        station_name, station),
-                    'href': '{}/collections/hydrometric-monthly-mean/items?STATION_NUMBER={}'.format(url, station)  # noqa
-                }, {
-                    'type': 'application/json',
-                    'rel': 'related',
-                    'title': 'Annual Maximum and Minimum Instantaneous Water Level or Discharge for {} ({})'.format(station_name, station),  # noqa
-                    'href': '{}/collections/hydrometric-annual-peaks/items?STATION_NUMBER={}'.format(url, station)  # noqa
-                }, {
-                    'type': 'application/json',
-                    'rel': 'related',
-                    'title': 'Annual Maximum and Minimum Daily Water Level or Discharge for {} ({})'.format(station_name, station),  # noqa
-                    'href': '{}/collections/hydrometric-annual-statistics/items?STATION_NUMBER={}'.format(url, station)  # noqa
-                }, {
-                    'type': 'text/html',
-                    'rel': 'alternate',
-                    'title': 'Station Information for {} ({})'.format(
-                        station_name, station),
-                    'href': 'https://wateroffice.ec.gc.ca/report/historical_e.html?stn={}'.format(station),  # noqa
-                    'hreflang': 'en-CA'
-                }, {
-                    'type': 'text/html',
-                    'rel': 'alternate',
-                    'title': 'Informations pour la station {} ({})'.format(
-                        station_name, station),
-                    'href': 'https://wateroffice.ec.gc.ca/report/historical_f.html?stn={}'.format(station),  # noqa
-                    'hreflang': 'fr-CA'
-                }]
-            },
-            'geometry': {
-                    'type': 'Point',
-                    'coordinates': station_coords
-            }
-        }
-
-        action = {
-            '_id': station,
-            '_index': 'hydrometric_stations',
-            '_op_type': 'update',
-            'doc': insert_dict,
-            'doc_as_upsert': True
-        }
-        yield action
-
-
-def generate_annual_stats(session, annual_stats_table, data_types_table,
-                          station_table, symbol_table):
-    """
-    Queries annual statistics data from the db, and reformats
-    data so it can be inserted into Elasticsearch.
-
-    Returns a generator of dictionaries that represent upsert actions
-    into Elasticsearch's bulk API.
-
-    :param session: SQLAlchemy session object.
-    :param annual_stats_table: table object to query annual stats data from.
-    :param data_types_table: table object to query data types data from.
-    :param station_table: table object to query station data from.
-    :param symbol_table: table object to query symbol data from.
-    :returns: generator of bulk API upsert actions.
-    """
-    results = session.query(annual_stats_table).group_by(annual_stats_table.c['STATION_NUMBER'], annual_stats_table.c['DATA_TYPE'], annual_stats_table.c['YEAR']).all() # noqa
-    results = [list(x) for x in results]
-    annual_stats_keys = annual_stats_table.columns.keys()
-    station_keys = station_table.columns.keys()
-    data_types_keys = data_types_table.columns.keys()
-    for result in results:
-        station_number = result[annual_stats_keys.index('STATION_NUMBER')]
-        data_type = result[annual_stats_keys.index('DATA_TYPE')]
-        year = result[annual_stats_keys.index('YEAR')]
-        min_month = result[annual_stats_keys.index('MIN_MONTH')]
-        min_day = result[annual_stats_keys.index('MIN_DAY')]
-        min_value = result[annual_stats_keys.index('MIN')]
-        min_symbol = result[annual_stats_keys.index('MIN_SYMBOL')]
-        max_month = result[annual_stats_keys.index('MAX_MONTH')]
-        max_day = result[annual_stats_keys.index('MAX_DAY')]
-        max_value = result[annual_stats_keys.index('MAX')]
-        max_symbol = result[annual_stats_keys.index('MAX_SYMBOL')]
-        args = {'STATION_NUMBER': station_number}
-        station_metadata = list(session.query(station_table).filter_by(**args).all()[0]) # noqa
-        args = {'DATA_TYPE': data_type}
-        data_type_metadata = list(session.query(data_types_table).filter_by(**args).all()[0]) # noqa
-        station_name = station_metadata[station_keys.index('STATION_NAME')]
-        province = station_metadata[station_keys.index('PROV_TERR_STATE_LOC')]
-        station_coords = [float(station_metadata[station_keys.index('LONGITUDE')]), # noqa
-                          float(station_metadata[station_keys.index('LATITUDE')])] # noqa
-        data_type_en = data_type_metadata[data_types_keys.index('DATA_TYPE_EN')] # noqa
-        data_type_fr = data_type_metadata[data_types_keys.index('DATA_TYPE_FR')] # noqa
-        if data_type_en == 'Flow':
-            data_type_en = 'Discharge'
-        if min_month is None or min_day is None:
-            min_date = None
-            LOGGER.warning('Could not find min date for station {}'.format(station_number)) # noqa
-        else:
-            min_date = '{}-{}-{}'.format(year, zero_pad(min_month),
-                                         zero_pad(min_day))
-        if max_month is None or max_day is None:
-            max_date = None
-            LOGGER.warning('Could not find max date for station {}'.format(station_number)) # noqa
-        else:
-            max_date = '{}-{}-{}'.format(year, zero_pad(max_month),
-                                         zero_pad(max_day))
-        symbol_keys = symbol_table.columns.keys()
-        if min_symbol is not None and min_symbol.strip():
-            args = {'SYMBOL_ID': min_symbol}
-            symbol_data = list(session.query(symbol_table).filter_by(**args).all()[0]) # noqa
-            min_symbol_en = symbol_data[symbol_keys.index('SYMBOL_EN')]
-            min_symbol_fr = symbol_data[symbol_keys.index('SYMBOL_FR')]
-        else:
-            min_symbol_en = min_symbol_fr = ''
-            LOGGER.warning('Could not find min symbol for station {}'.format(station_number)) # noqa
-        if max_symbol is not None and max_symbol.strip():
-            args = {'SYMBOL_ID': max_symbol}
-            symbol_data = list(session.query(symbol_table).filter_by(**args).all()[0]) # noqa
-            max_symbol_en = symbol_data[symbol_keys.index('SYMBOL_EN')]
-            max_symbol_fr = symbol_data[symbol_keys.index('SYMBOL_FR')]
-        else:
-            max_symbol_en = max_symbol_fr = ''
-            LOGGER.warning('Could not find max symbol for station {}'.format(station_number)) # noqa
-        if data_type_en == 'Water Level':
-            es_id = '{}.{}.level-niveaux'.format(station_number, year)
-        elif data_type_en == 'Discharge':
-            es_id = '{}.{}.discharge-debit'.format(station_number, year)
-        elif data_type_en == 'Sediment in mg/L':
-            es_id = '{}.{}.sediment-sediment'.format(station_number, year)
-        elif data_type_en == 'Daily Mean Tonnes':
-            es_id = '{}.{}.tonnes-tonnes'.format(station_number, year)
-        else:
-            es_id = '{}.{}.None'.format(station_number, year)
-        insert_dict = {
-            'type': 'Feature',
-            'properties': {
-                'STATION_NAME': station_name,
-                'IDENTIFIER': es_id,
-                'STATION_NUMBER': station_number,
-                'PROV_TERR_STATE_LOC': province,
-                'DATA_TYPE_EN': data_type_en,
-                'DATA_TYPE_FR': data_type_fr,
-                'MIN_DATE': min_date,
-                'MIN_VALUE': float(min_value) if min_value else None,
-                'MIN_SYMBOL_EN': min_symbol_en,
-                'MIN_SYMBOL_FR': min_symbol_fr,
-                'MAX_DATE': max_date,
-                'MAX_VALUE': float(max_value) if max_value else None,
-                'MAX_SYMBOL_EN': max_symbol_en,
-                'MAX_SYMBOL_FR': max_symbol_fr
-            },
-            'geometry': {
-                'type': 'Point',
-                'coordinates': station_coords
-            }
-        }
-        action = {
-            '_id': es_id,
-            '_index': 'hydrometric_annual_statistics',
-            '_op_type': 'update',
-            'doc': insert_dict,
-            'doc_as_upsert': True
-        }
-        yield action
-
-
-def generate_annual_peaks(session, metadata, annual_peaks_table,
-                          data_types_table, symbol_table, station_table):
-    """
-    Queries annual peaks data from the db, and reformats
-    data so it can be inserted into Elasticsearch.
-
-    Returns a generator of dictionaries that represent upsert actions
-    into Elasticsearch's bulk API.
-
-    :param session: SQLAlchemy session object.
-    :param metadata: db metadata returned by connect_db.
-    :param annual_peaks_table: table object to query annual peaks data from.
-    :param data_types_table: table object to query data types data from.
-    :param symbol_table: table object to query symbol data from.
-    :param station_table: table object to query station data from.
-    :returns: generator of bulk API upsert actions.
-    """
-    tz_map = {None: None, '*': None, '0': None, 'AKST': '-9', 'AST': '-4',
-              'CST': '-6', 'EST': '-5', 'MDT': '-6', 'MST': '-7',
-              'NST': '-3.5', 'PST': '-8', 'YST': '-9'}
-    annual_peaks_keys = annual_peaks_table.columns.keys()
-    station_keys = station_table.columns.keys()
-    data_types_keys = data_types_table.columns.keys()
-    results = session.query(annual_peaks_table).group_by(annual_peaks_table.c['STATION_NUMBER'], annual_peaks_table.c['DATA_TYPE'], annual_peaks_table.c['YEAR'], annual_peaks_table.c['PEAK_CODE']).all() # noqa
-    results = [list(x) for x in results]
-    for result in results:
-        station_number = result[annual_peaks_keys.index('STATION_NUMBER')]
-        data_type = result[annual_peaks_keys.index('DATA_TYPE')]
-        year = result[annual_peaks_keys.index('YEAR')]
-        peak_id = result[annual_peaks_keys.index('PEAK_CODE')]
-        unit_id = result[annual_peaks_keys.index('PRECISION_CODE')]
-        month = result[annual_peaks_keys.index('MONTH')]
-        day = result[annual_peaks_keys.index('DAY')]
-        hour = result[annual_peaks_keys.index('HOUR')]
-        minute = result[annual_peaks_keys.index('MINUTE')]
-        time_zone = tz_map[result[annual_peaks_keys.index('TIME_ZONE')]]
-        peak_value = result[annual_peaks_keys.index('PEAK')]
-        symbol_id = result[annual_peaks_keys.index('SYMBOL')]
-        if month is None or day is None:
-            date = None
-            LOGGER.warning('Could not find date for station {}'.format(station_number)) # noqa
-        elif hour is None or minute is None:
-            date = '{}-{}-{}'.format(year, zero_pad(month), zero_pad(day))
-        else:
-            date = '{}-{}-{}T{}:{}'.format(year, zero_pad(month),
-                                           zero_pad(day), zero_pad(hour),
-                                           zero_pad(minute))
-        args = {'STATION_NUMBER': station_number}
-        try:
-            station_metadata = list(session.query(station_table).filter_by(**args).all()[0]) # noqa
-            station_name = station_metadata[station_keys.index('STATION_NAME')]
-            province = station_metadata[station_keys.index(
-                'PROV_TERR_STATE_LOC')]
-            station_coords = [float(station_metadata[station_keys.index('LONGITUDE')]), # noqa
-                          float(station_metadata[station_keys.index('LATITUDE')])] # noqa
-        except Exception:
-            station_name = None
-            province = None
-            station_coords = [None, None]
-            LOGGER.warning('Could not find station information for station {}'.format(station_number)) # noqa
-        args = {'DATA_TYPE': data_type}
-        data_type_metadata = list(session.query(data_types_table).filter_by(**args).all()[0]) # noqa
-        data_type_en = data_type_metadata[data_types_keys.index('DATA_TYPE_EN')] # noqa
-        data_type_fr = data_type_metadata[data_types_keys.index('DATA_TYPE_FR')] # noqa
-        if data_type_en == 'Flow':
-            data_type_en = 'Discharge'
-        if unit_id:
-            unit_codes = get_table_var(metadata, 'PRECISION_CODES')
-            unit_keys = unit_codes.columns.keys()
-            args = {'PRECISION_CODE': unit_id}
-            unit_data = list(session.query(unit_codes).filter_by(**args).all()[0]) # noqa
-            unit_en = unit_data[unit_keys.index('PRECISION_EN')]
-            unit_fr = unit_data[unit_keys.index('PRECISION_FR')]
-        else:
-            unit_en = unit_fr = None
-            LOGGER.warning('Could not find units for station {}'.format(station_number)) # noqa
-        if peak_id:
-            peak_codes = get_table_var(metadata, 'PEAK_CODES')
-            peak_keys = peak_codes.columns.keys()
-            args = {'PEAK_CODE': peak_id}
-            peak_data = list(session.query(peak_codes).filter_by(**args).all()[0]) # noqa
-            peak_en = peak_data[peak_keys.index('PEAK_EN')]
-            peak_fr = peak_data[peak_keys.index('PEAK_FR')]
-        else:
-            peak_en = peak_fr = None
-            LOGGER.warning('Could not find peaks for station {}'.format(station_number)) # noqa
-        if symbol_id and symbol_id.strip():
-            symbol_keys = symbol_table.columns.keys()
-            args = {'SYMBOL_ID': symbol_id}
-            symbol_data = list(session.query(symbol_table).filter_by(**args).all()[0]) # noqa
-            symbol_en = symbol_data[symbol_keys.index('SYMBOL_EN')]
-            symbol_fr = symbol_data[symbol_keys.index('SYMBOL_FR')]
-        else:
-            symbol_en = symbol_fr = None
-            LOGGER.warning('Could not find symbol for station {}'.format(station_number)) # noqa
-        if peak_en == 'Maximum':
-            peak = 'maximum-maximale'
-        elif peak_en == 'Minimum':
-            peak = 'minimum-minimale'
-        else:
-            peak = None
-
-        if data_type_en == 'Water Level':
-            es_id = '{}.{}.level-niveaux.{}'.format(station_number, year, peak)
-        elif data_type_en == 'Discharge':
-            es_id = '{}.{}.discharge-debit.{}'.format(station_number, year,
-                                                      peak)
-        elif data_type_en == 'Sediment in mg/L':
-            es_id = '{}.{}.sediment-sediment.{}'.format(station_number,
-                                                        year, peak)
-        elif data_type_en == 'Daily Mean Tonnes':
-            es_id = '{}.{}.tonnes-tonnes.{}'.format(station_number, year, peak)
-        else:
-            es_id = '{}.{}.None'.format(station_number, year)
-        insert_dict = {
-            'type': 'Feature',
-            'properties': {
-                'STATION_NAME': station_name,
-                'STATION_NUMBER': station_number,
-                'PROV_TERR_STATE_LOC': province,
-                'IDENTIFIER': es_id,
-                'DATA_TYPE_EN': data_type_en,
-                'DATA_TYPE_FR': data_type_fr,
-                'DATE': date,
-                'TIMEZONE_OFFSET': time_zone,
-                'PEAK_CODE_EN': peak_en,
-                'PEAK_CODE_FR': peak_fr,
-                'PEAK': peak_value,
-                'UNITS_EN': unit_en,
-                'UNITS_FR': unit_fr,
-                'SYMBOL_EN': symbol_en,
-                'SYMBOL_FR': symbol_fr
-            },
-            'geometry': {
-                'type': 'Point',
-                'coordinates': station_coords
-            }
-        }
-        action = {
-            '_id': es_id,
-            '_index': 'hydrometric_annual_peaks',
-            '_op_type': 'update',
-            'doc': insert_dict,
-            'doc_as_upsert': True
-        }
-        yield action
+@click.group()
+def hydat():
+    """Manages hydat indices"""
+    pass
 
 
 @click.command()
 @click.pass_context
-@click.option('--db', type=click.Path(exists=True, resolve_path=True),
-              help='Path to Hydat sqlite database')
-@click.option('--es', help='URL to Elasticsearch')
-@click.option('--username', help='Username to connect to HTTPS')
-@click.option('--password', help='Password to connect to HTTPS')
-@click.option('--dataset', help='ES dataset to load, or all\
-                                 if loading everything')
-def hydat(ctx, db, es, username, password, dataset):
+@cli_options.OPTION_DB(help='Path to Hydat sqlite database')
+@cli_options.OPTION_ELASTICSEARCH()
+@cli_options.OPTION_ES_USERNAME()
+@cli_options.OPTION_ES_PASSWORD()
+@cli_options.OPTION_DATASET(
+    type=click.Choice(
+        [
+            'all',
+            'stations',
+            'observations',
+            'annual-statistics',
+            'annual-peaks',
+        ]
+    )
+)
+def add(ctx, db, es, username, password, dataset):
     """
-    Loads HYDAT data into Elasticsearch
+    Loads HYDAT data into Elasticsearch.
 
     Controls transformation from sqlite to Elasticsearch.
 
@@ -1135,111 +1238,158 @@ def hydat(ctx, db, es, username, password, dataset):
     :param password: password for HTTP authentication.
     :param dataset: name of dataset to load, or all for all datasets.
     """
-    auth = (username, password)
-    es_client = util.get_es(es, auth)
-    try:
-        engine, session, metadata = connect_db('sqlite:///{}'.format(db))
-    except Exception as err:
-        LOGGER.critical('Could not connect to database due to: {}. Exiting.').format(str(err)) # noqa
-        return None
+
+    plugin_def = {
+        'db_string': db,
+        'es_conn_dict': {'host': es, 'auth': (username, password)}
+        if all([es, username, password])
+        else None,
+        'handler': 'msc_pygeoapi.loader.hydate.HydatLoader',
+    }
+
+    loader = HydatLoader(plugin_def)
+
     try:
         LOGGER.info('Accessing SQLite tables...')
         discharge_var = level_var = station_table = None
-        level_var = get_table_var(metadata, 'DLY_LEVELS')
-        discharge_var = get_table_var(metadata, 'DLY_FLOWS')
-        station_table = get_table_var(metadata, 'STATIONS')
-        data_types_table = get_table_var(metadata, 'DATA_TYPES')
-        annual_stats_table = get_table_var(metadata, 'ANNUAL_STATISTICS')
-        symbol_table = get_table_var(metadata, 'DATA_SYMBOLS')
-        annual_peaks_table = get_table_var(metadata, 'ANNUAL_INSTANT_PEAKS')
+        level_var = loader.get_table_var('DLY_LEVELS')
+        discharge_var = loader.get_table_var('DLY_FLOWS')
+        station_table = loader.get_table_var('STATIONS')
+        data_types_table = loader.get_table_var('DATA_TYPES')
+        annual_stats_table = loader.get_table_var('ANNUAL_STATISTICS')
+        symbol_table = loader.get_table_var('DATA_SYMBOLS')
+        annual_peaks_table = loader.get_table_var('ANNUAL_INSTANT_PEAKS')
         LOGGER.info('Success. Created table variables.')
     except Exception as err:
-        LOGGER.critical('Could not create table variables due to: {}. Exiting.').format(str(err)) # noqa
-        return None
+        LOGGER.critical(
+            'Could not create table variables due to: {str(err)}. Exiting.'
+        )
+        raise err
 
     if dataset == 'all':
         try:
             LOGGER.info('Populating stations index...')
-            create_index(es_client, 'stations')
-            stations = generate_stations(session, metadata, es, station_table)
+            loader.create_index('stations')
+            stations = loader.generate_stations(station_table)
 
-            util.submit_elastic_package(es_client, stations)
+            submit_elastic_package(loader.ES, stations)
             LOGGER.info('Stations index populated.')
         except Exception as err:
-            LOGGER.error('Could not populate stations due to: {}.'.format(str(err))) # noqa
+            LOGGER.error(f'Could not populate stations due to: {str(err)}.')
         try:
             LOGGER.info('Populating observations indexes...')
-            create_index(es_client, 'observations')
-            means = generate_means(session, discharge_var, level_var, station_table, symbol_table) # noqa
+            loader.create_index('observations')
+            means = loader.generate_means(
+                discharge_var, level_var, station_table, symbol_table
+            )
 
-            util.submit_elastic_package(es_client, means)
+            submit_elastic_package(loader.ES, means)
             LOGGER.info('Observations populated.')
         except Exception as err:
-            LOGGER.error('Could not populate observations due to: {}.'.format(str(err))) # noqa
+            LOGGER.error(
+                f'Could not populate observations due to: {str(err)}.'
+            )
         try:
             LOGGER.info('Populating annual statistics index...')
-            create_index(es_client, 'annual_statistics')
-            stats = generate_annual_stats(session, annual_stats_table, data_types_table, station_table, symbol_table) # noqa
+            loader.create_index('annual_statistics')
+            stats = loader.generate_annual_stats(
+                annual_stats_table,
+                data_types_table,
+                station_table,
+                symbol_table,
+            )
 
-            util.submit_elastic_package(es_client, stats)
+            submit_elastic_package(loader.ES, stats)
             LOGGER.info('Annual stastistics index populated.')
         except Exception as err:
-            LOGGER.error('Could not populate annual statistics due to: {}.'.format(str(err))) # noqa
+            LOGGER.error(
+                f'Could not populate annual statistics due to: {str(err)}.'
+            )
         try:
             LOGGER.info('Populating annual peaks index...')
-            create_index(es_client, 'annual_peaks')
-            peaks = generate_annual_peaks(session, metadata, annual_peaks_table, data_types_table, symbol_table, station_table) # noqa
+            loader.create_index('annual_peaks')
+            peaks = loader.generate_annual_peaks(
+                annual_peaks_table,
+                data_types_table,
+                symbol_table,
+                station_table,
+            )
 
-            util.submit_elastic_package(es_client, peaks)
+            submit_elastic_package(loader.ES, peaks)
             LOGGER.info('Annual peaks index populated.')
         except Exception as err:
-            LOGGER.error('Could not populate annual peaks due to: {}.'.format(str(err))) # noqa
+            LOGGER.error(
+                f'Could not populate annual peaks due to: {str(err)}.'
+            )
         LOGGER.info('Finished populating all indices.')
 
     elif dataset == 'stations':
         try:
             LOGGER.info('Populating stations index...')
-            create_index(es_client, 'stations')
-            stations = generate_stations(session, metadata, es, station_table)
+            loader.create_index('stations')
+            stations = loader.generate_stations(station_table)
 
-            util.submit_elastic_package(es_client, stations)
+            submit_elastic_package(loader.ES, stations)
             LOGGER.info('Stations index populated.')
         except Exception as err:
-            LOGGER.error('Could not populate stations due to: {}.'.format(str(err))) # noqa
+            LOGGER.error(f'Could not populate stations due to: {str(err)}.')
 
     elif dataset == 'observations':
         try:
             LOGGER.info('Populating observations indexes...')
-            create_index(es_client, 'observations')
-            means = generate_means(session, discharge_var, level_var, station_table, symbol_table) # noqa
+            loader.create_index('observations')
+            means = loader.generate_means(
+                discharge_var, level_var, station_table, symbol_table
+            )
 
-            util.submit_elastic_package(es_client, means)
+            submit_elastic_package(loader.ES, means)
             LOGGER.info('Observations populated.')
         except Exception as err:
             raise
-            LOGGER.error('Could not populate observations due to: {}.'.format(str(err))) # noqa
+            LOGGER.error(
+                f'Could not populate observations due to: {str(err)}.'
+            )
 
     elif dataset == 'annual-statistics':
         try:
             LOGGER.info('Populating annual statistics index...')
-            create_index(es_client, 'annual_statistics')
-            stats = generate_annual_stats(session, annual_stats_table, data_types_table, station_table, symbol_table) # noqa
+            loader.create_index('annual_statistics')
+            stats = loader.generate_annual_stats(
+                annual_stats_table,
+                data_types_table,
+                station_table,
+                symbol_table,
+            )
 
-            util.submit_elastic_package(es_client, stats)
+            submit_elastic_package(loader.ES, stats)
             LOGGER.info('Annual stastistics index populated.')
         except Exception as err:
-            LOGGER.error('Could not populate annual statistics due to: {}.'.format(str(err))) # noqa
+            LOGGER.error(
+                f'Could not populate annual statistics due to: {str(err)}.'
+            )
 
     elif dataset == 'annual-peaks':
         try:
             LOGGER.info('Populating annual peaks index...')
-            create_index(es_client, 'annual_peaks')
-            peaks = generate_annual_peaks(session, metadata, annual_peaks_table, data_types_table, symbol_table, station_table) # noqa
+            loader.create_index('annual_peaks')
+            peaks = loader.generate_annual_peaks(
+                annual_peaks_table,
+                data_types_table,
+                symbol_table,
+                station_table,
+            )
 
-            util.submit_elastic_package(es_client, peaks)
+            submit_elastic_package(loader.ES, peaks)
             LOGGER.info('Annual peaks index populated.')
         except Exception as err:
-            LOGGER.error('Could not populate annual peaks due to: {}.'.format(str(err))) # noqa
-
+            LOGGER.error(
+                f'Could not populate annual peaks due to: {str(err)}.'
+            )
+            raise err
     else:
-        LOGGER.critical('Unknown dataset parameter {}, skipping index population.'.format(dataset)) # noqa
+        LOGGER.critical(
+            f'Unknown dataset parameter {dataset}, skipping index population.'
+        )
+
+
+hydat.add_command(add)

--- a/msc_pygeoapi/loader/hydrometric_realtime.py
+++ b/msc_pygeoapi/loader/hydrometric_realtime.py
@@ -35,10 +35,11 @@ import os
 import urllib.request
 from elasticsearch import helpers, logger as elastic_logger
 
+from msc_pygeoapi import cli_options
 from msc_pygeoapi.env import (MSC_PYGEOAPI_CACHEDIR, MSC_PYGEOAPI_ES_TIMEOUT,
                               MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH)
 from msc_pygeoapi.loader.base import BaseLoader
-from msc_pygeoapi.util import click_abort_if_false, get_es
+from msc_pygeoapi.util import get_es
 
 
 LOGGER = logging.getLogger(__name__)
@@ -435,12 +436,13 @@ def cache_stations(ctx):
 
 @click.command()
 @click.pass_context
-@click.option('--days', '-d', default=DAYS_TO_KEEP, type=int,
-              help='delete documents older than n days (default={})'.format(
-                  DAYS_TO_KEEP))
-@click.option('--yes', is_flag=True, callback=click_abort_if_false,
-              expose_value=False,
-              prompt='Are you sure you want to delete old documents?')
+@cli_options.OPTION_DAYS(
+    default=DAYS_TO_KEEP,
+    help='Delete documents older than n days (default={})'
+)
+@cli_options.OPTION_YES(
+    prompt='Are you sure you want to delete old documents?'
+)
 def clean_records(ctx, days):
     """Delete old documents"""
 
@@ -473,9 +475,9 @@ def clean_records(ctx, days):
 
 @click.command()
 @click.pass_context
-@click.option('--yes', is_flag=True, callback=click_abort_if_false,
-              expose_value=False,
-              prompt='Are you sure you want to delete these indexes?')
+@cli_options.OPTION_YES(
+    prompt='Are you sure you want to delete these indexes?'
+)
 def delete_index(ctx):
     """Delete hydrometric realtime indexes"""
 

--- a/msc_pygeoapi/loader/marine_weather_realtime.py
+++ b/msc_pygeoapi/loader/marine_weather_realtime.py
@@ -38,6 +38,7 @@ from elasticsearch import helpers, exceptions, logger as elastic_logger
 from lxml import etree
 from parse import parse
 
+from msc_pygeoapi import cli_options
 from msc_pygeoapi.env import (
     MSC_PYGEOAPI_BASEPATH,
     MSC_PYGEOAPI_ES_TIMEOUT,
@@ -761,22 +762,8 @@ def marine_weather():
 
 @click.command()
 @click.pass_context
-@click.option(
-    '--file',
-    '-f',
-    'file_',
-    type=click.Path(exists=True, resolve_path=True),
-    help='Path to file',
-)
-@click.option(
-    '--directory',
-    '-d',
-    'directory',
-    type=click.Path(
-        exists=True, resolve_path=True, dir_okay=True, file_okay=False
-    ),
-    help='Path to directory',
-)
+@cli_options.OPTION_FILE()
+@cli_options.OPTION_DIRECTORY()
 def add(ctx, file_, directory):
     """add data to system"""
 
@@ -810,12 +797,7 @@ def add(ctx, file_, directory):
 
 @click.command()
 @click.pass_context
-@click.option(
-    '--index_name',
-    '-i',
-    type=click.Choice(INDICES),
-    help='msc-pygeoapi marine weather  index name to delete',
-)
+@cli_options.OPTION_INDEX_NAME(type=click.Choice(INDICES))
 def delete_index(ctx, index_name):
     """
     Delete a particular ES index with a given name as argument or all if no

--- a/msc_pygeoapi/loader/swob_realtime.py
+++ b/msc_pygeoapi/loader/swob_realtime.py
@@ -39,10 +39,11 @@ import os
 from elasticsearch import helpers, logger as elastic_logger
 from lxml import etree
 
+from msc_pygeoapi import cli_options
 from msc_pygeoapi.env import (MSC_PYGEOAPI_CACHEDIR, MSC_PYGEOAPI_ES_TIMEOUT,
                               MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH)
 from msc_pygeoapi.loader.base import BaseLoader
-from msc_pygeoapi.util import click_abort_if_false, get_es, json_pretty_print
+from msc_pygeoapi.util import get_es, json_pretty_print
 
 
 LOGGER = logging.getLogger(__name__)
@@ -399,12 +400,13 @@ def add(ctx, file_, directory):
 
 @click.command()
 @click.pass_context
-@click.option('--days', '-d', default=DAYS_TO_KEEP, type=int,
-              help='delete documents older than n days (default={})'.format(
-                  DAYS_TO_KEEP))
-@click.option('--yes', is_flag=True, callback=click_abort_if_false,
-              expose_value=False,
-              prompt='Are you sure you want to delete old documents?')
+@cli_options.OPTION_DAYS(
+    default=DAYS_TO_KEEP,
+    help=f'Delete documents older than n days (default={DAYS_TO_KEEP})'
+)
+@cli_options.OPTION_YES(
+    prompt='Are you sure you want to delete old documents?'
+)
 def clean_records(ctx, days):
     """Delete old documents"""
 
@@ -437,9 +439,9 @@ def clean_records(ctx, days):
 
 @click.command()
 @click.pass_context
-@click.option('--yes', is_flag=True, callback=click_abort_if_false,
-              expose_value=False,
-              prompt='Are you sure you want to delete these indexes?')
+@cli_options.OPTION_YES(
+    prompt='Are you sure you want to delete these indexes?'
+)
 def delete_index(ctx):
     """Delete SWOB realtime indexes"""
 


### PR DESCRIPTION
As per #59,

Refactors common CLI options into `cli_options.py`. Since a common CLI option may have a different `prompt` or `help` keyword argument value, I have written this as functions where `*args` and `**kwargs` can be passed. If they are, the default options are replaced with the passed values.

Also, this MR contains a major refactor of the following 3 loaders: `hydat.py`, `ahccd.py` and `climate_archive.py` in order to bring them up to date with the newer loaders which use the `BaseLoader` class.

I have tested most of the loaders to ensure that the changes are working as intended and have no found any issues.