### PR TITLE
minor fixes to LTCE loader and config

### DIFF
--- a/deploy/default/msc-pygeoapi-config.yml
+++ b/deploy/default/msc-pygeoapi-config.yml
@@ -941,7 +941,7 @@ resources:
         providers:
             - type: feature
               name: Elasticsearch
-              data: http://localhost:9200/ltce_precip_extremes
+              data: http://localhost:9200/ltce_snow_extremes
               id_field: IDENTIFIER
 
 

--- a/msc_pygeoapi/loader/ltce.py
+++ b/msc_pygeoapi/loader/ltce.py
@@ -220,18 +220,6 @@ MAPPINGS = {
             'format': 'date_time_no_millis',
             'ignore_malformed': False,
         },
-        'CLIMATE_IDENTIFIER': {
-            'type': 'text',
-            'fields': {'raw': {'type': 'keyword'}},
-        },
-        'ENG_STN_NAME': {
-            'type': 'text',
-            'fields': {'raw': {'type': 'keyword'}},
-        },
-        'FRE_STN_NAME': {
-            'type': 'text',
-            'fields': {'raw': {'type': 'keyword'}},
-        },
         'IDENTIFIER': {
             'type': 'text',
             'fields': {'raw': {'type': 'keyword'}},
@@ -286,18 +274,6 @@ MAPPINGS = {
             'format': 'date_time_no_millis',
             'ignore_malformed': False,
         },
-        'CLIMATE_IDENTIFIER': {
-            'type': 'text',
-            'fields': {'raw': {'type': 'keyword'}},
-        },
-        'ENG_STN_NAME': {
-            'type': 'text',
-            'fields': {'raw': {'type': 'keyword'}},
-        },
-        'FRE_STN_NAME': {
-            'type': 'text',
-            'fields': {'raw': {'type': 'keyword'}},
-        },
         'IDENTIFIER': {
             'type': 'text',
             'fields': {'raw': {'type': 'keyword'}},
@@ -351,18 +327,6 @@ MAPPINGS = {
             'type': 'date',
             'format': 'date_time_no_millis',
             'ignore_malformed': False,
-        },
-        'CLIMATE_IDENTIFIER': {
-            'type': 'text',
-            'fields': {'raw': {'type': 'keyword'}},
-        },
-        'ENG_STN_NAME': {
-            'type': 'text',
-            'fields': {'raw': {'type': 'keyword'}},
-        },
-        'FRE_STN_NAME': {
-            'type': 'text',
-            'fields': {'raw': {'type': 'keyword'}},
         },
         'IDENTIFIER': {
             'type': 'text',
@@ -587,6 +551,8 @@ class LtceLoader(BaseLoader):
             # cleanup unwanted fields retained from SQL join
             fields_to_delete = [
                 'STN_ID',
+                'ENG_PROV_NAME',
+                'FRE_PROV_NAME',
                 'REGION_CODE',
                 'CRITERIA',
                 'NOTES',
@@ -748,8 +714,16 @@ class LtceLoader(BaseLoader):
                 ] = stations_dict[virtual_climate_id][level]['record_end']
 
             # cleanup unwanted fields retained from SQL join
-            del insert_dict['LOCAL_TIME']
-            del insert_dict['VIRTUAL_MEAS_DISPLAY_CODE']
+            # cleanup unwanted fields retained from SQL join
+            fields_to_delete = [
+                'LOCAL_TIME',
+                'VIRTUAL_MEAS_DISPLAY_CODE',
+                'ENG_STN_NAME',
+                'FRE_STN_NAME',
+                'CLIMATE_IDENTIFIER',
+            ]
+            for field in fields_to_delete:
+                del insert_dict[field]
 
             # set properties.IDENTIFIER
             insert_dict['IDENTIFIER'] = es_id
@@ -850,8 +824,16 @@ class LtceLoader(BaseLoader):
             ]
 
             # cleanup unwanted fields retained from SQL join
-            del insert_dict['LOCAL_TIME']
-            del insert_dict['VIRTUAL_MEAS_DISPLAY_CODE']
+            fields_to_delete = [
+                'LOCAL_TIME',
+                'VIRTUAL_MEAS_DISPLAY_CODE',
+                'ENG_STN_NAME',
+                'FRE_STN_NAME',
+                'CLIMATE_IDENTIFIER',
+                'LAST_UPDATED',
+            ]
+            for field in fields_to_delete:
+                del insert_dict[field]
 
             # set properties.IDENTIFIER
             insert_dict['IDENTIFIER'] = es_id

--- a/msc_pygeoapi/loader/ltce.py
+++ b/msc_pygeoapi/loader/ltce.py
@@ -562,7 +562,7 @@ class LtceLoader(BaseLoader):
                 'LAT',
             ]
             for field in fields_to_delete:
-                del insert_dict[field]
+                insert_dict.pop(field)
 
             # set properties.IDENTIFIER
             insert_dict['IDENTIFIER'] = es_id
@@ -723,7 +723,7 @@ class LtceLoader(BaseLoader):
                 'CLIMATE_IDENTIFIER',
             ]
             for field in fields_to_delete:
-                del insert_dict[field]
+                insert_dict.pop(field)
 
             # set properties.IDENTIFIER
             insert_dict['IDENTIFIER'] = es_id
@@ -833,7 +833,7 @@ class LtceLoader(BaseLoader):
                 'LAST_UPDATED',
             ]
             for field in fields_to_delete:
-                del insert_dict[field]
+                insert_dict.pop(field)
 
             # set properties.IDENTIFIER
             insert_dict['IDENTIFIER'] = es_id
@@ -932,8 +932,8 @@ class LtceLoader(BaseLoader):
             ]
 
             # cleanup unwanted fields retained from SQL join
-            del insert_dict['LOCAL_TIME']
-            del insert_dict['VIRTUAL_MEAS_DISPLAY_CODE']
+            insert_dict.pop('LOCAL_TIME')
+            insert_dict.pop('VIRTUAL_MEAS_DISPLAY_CODE')
 
             # set properties.IDENTIFIER
             insert_dict['IDENTIFIER'] = es_id


### PR DESCRIPTION
This MR fxes an error in `deploy/default/msc-pygeoapi-config.yml` where the LTCE snowfall collection was pointing to the wrong ES index.

It also removes additional keys from the dictionaries created by the various SQL joins in the LTCE loader as per request from the data steward.