### PR TITLE
fix error in ogr import

### DIFF
--- a/msc_pygeoapi/loader/forecast_polygons.py
+++ b/msc_pygeoapi/loader/forecast_polygons.py
@@ -34,7 +34,7 @@ from pathlib import Path
 import click
 from elasticsearch import helpers, logger as elastic_logger
 from parse import parse
-from gdal import ogr
+from osgeo import ogr
 
 from msc_pygeoapi import cli_options
 from msc_pygeoapi.env import (

--- a/msc_pygeoapi/loader/hurricanes_realtime.py
+++ b/msc_pygeoapi/loader/hurricanes_realtime.py
@@ -37,7 +37,7 @@ import click
 from elasticsearch import helpers, logger as elastic_logger
 from elasticsearch.exceptions import ConflictError
 from parse import parse
-from gdal import ogr
+from osgeo import ogr
 
 from msc_pygeoapi.env import (MSC_PYGEOAPI_ES_TIMEOUT, MSC_PYGEOAPI_ES_URL,
                               MSC_PYGEOAPI_ES_AUTH)


### PR DESCRIPTION
Modifies `from gdal import ogr` statements to `from osgeo import ogr`.

The previous method was valid but seems to no longer work. According to their documentation `from osgeo import ogr` is the valid way to do this now.

This was creating an issue where all `msc-pygeoapi data` CLI sub-commands were not loaded.