### PR TITLE
try/except geomet_climate import via imp

### DIFF
--- a/msc_pygeoapi/loader/hurricanes_realtime.py
+++ b/msc_pygeoapi/loader/hurricanes_realtime.py
@@ -583,7 +583,7 @@ def delete_index(ctx, index_name):
             return True
     else:
         if click.confirm(
-                'Are you sure you want to delete {} marine forecast'
+                'Are you sure you want to delete {} hurricane'
                 ' indices ({})?'.format(click.style('ALL', fg='red'),
                                         click.style(", ".join(INDICES),
                                                     fg='red')),

--- a/msc_pygeoapi/process/cccs/__init__.py
+++ b/msc_pygeoapi/process/cccs/__init__.py
@@ -30,14 +30,25 @@
 
 import click
 import imp
+import logging
 
 from msc_pygeoapi.process.cccs.raster_drill import raster_drill_execute
+
+LOGGER = logging.getLogger(__name__)
 
 GEOMET_CLIMATE_CONFIG = '/opt/geomet-climate/geomet-climate.yml'
 GEOMET_CLIMATE_BASEPATH = '/data/geomet/feeds/dd.ops/climate'
 GEOMET_CLIMATE_BASEPATH_VRT = '/opt/geomet-climate/vrt'
-GEOMET_CLIMATE_EPSG = '{}/{}'.format(imp.find_module('geomet_climate')[1],
-                                     '/resources/mapserv')
+try:
+    GEOMET_CLIMATE_EPSG = '{}/{}'.format(
+        imp.find_module('geomet_climate')[1], '/resources/mapserv'
+    )
+except ImportError:
+    LOGGER.warning(
+        "Could not import geomet_climate module."
+        " Ensure geomet-climate is installed in order to use cccs processes."
+    )
+    GEOMET_CLIMATE_EPSG = None
 
 
 @click.group()

--- a/msc_pygeoapi/process/cccs/raster_drill.py
+++ b/msc_pygeoapi/process/cccs/raster_drill.py
@@ -425,7 +425,10 @@ def raster_drill(layer, x, y, format_):
                                            GEOMET_CLIMATE_BASEPATH_VRT,
                                            GEOMET_CLIMATE_EPSG)
 
-    pyproj.set_datapath(GEOMET_CLIMATE_EPSG)
+    if GEOMET_CLIMATE_EPSG is not None:
+        pyproj.set_datapath(GEOMET_CLIMATE_EPSG)
+    else:
+        raise Exception("Could not locate geomet-climate EPSG file.")
 
     LOGGER.info('start raster drilling')
 


### PR DESCRIPTION
Adds a try/except when using the `imp.find_module()` method to locate the geomet-climate EPSG file in case geomet-climate is not installed.

This was causing the CLI to fail completely with an ImportError otherwise.