### PR TITLE
allow passing ES connection settings when managing indexes via CLI

### DIFF
--- a/msc_pygeoapi/loader/bulletins.py
+++ b/msc_pygeoapi/loader/bulletins.py
@@ -184,13 +184,26 @@ def bulletins():
     default=DAYS_TO_KEEP,
     help='Delete indexes older than n days (default={})'
 )
+@cli_options.OPTION_ELASTICSEARCH()
+@cli_options.OPTION_ES_USERNAME()
+@cli_options.OPTION_ES_PASSWORD()
 @cli_options.OPTION_YES(
     prompt='Are you sure you want to delete old indexes?'
 )
-def clean_indexes(ctx, days):
-    """Delete old indexes"""
+def clean_indexes(ctx, days, es, username, password):
+    """Clean indexes older than n number of days"""
 
-    es = get_es(MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH)
+    # if es, username and and password passed, use to create ES connection
+    if all([es, username, password]):
+        es_conn_dict = {
+            'host': es,
+            'auth': (username, password)
+        }
+        es = get_es(es_conn_dict['host'], es_conn_dict['auth'])
+    # otherwise use environment variables
+    else:
+        es_conn_dict = {}
+        es = get_es(MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH)
 
     indexes = list(es.indices.get('{}*'.format(INDEX_BASENAME)).keys())
 
@@ -198,23 +211,34 @@ def clean_indexes(ctx, days):
         indexes_to_delete = check_es_indexes_to_delete(indexes, days)
         if indexes_to_delete:
             click.echo('Deleting indexes {}'.format(indexes_to_delete))
-            delete_es_indexes(','.join(indexes))
+            delete_es_indexes(','.join(indexes), conn_dict=es_conn_dict)
 
     click.echo('Done')
 
 
 @click.command()
 @click.pass_context
+@cli_options.OPTION_ELASTICSEARCH()
+@cli_options.OPTION_ES_USERNAME()
+@cli_options.OPTION_ES_PASSWORD()
 @cli_options.OPTION_YES(
     prompt='Are you sure you want to delete these indexes?'
 )
-def delete_indexes(ctx):
-    """Delete all hydrometric realtime indexes"""
+def delete_indexes(ctx, es, username, password):
+    """Delete all bulletin realtime indexes"""
 
     all_indexes = '{}*'.format(INDEX_BASENAME)
 
     click.echo('Deleting indexes {}'.format(all_indexes))
-    delete_es_indexes(all_indexes)
+
+    if all([es, username, password]):
+        es_conn_dict = {
+            'host': es,
+            'auth': (username, password)
+        }
+        delete_es_indexes(all_indexes, conn_dict=es_conn_dict)
+    else:
+        delete_es_indexes(all_indexes)
 
     click.echo('Done')
 

--- a/msc_pygeoapi/loader/climate_archive.py
+++ b/msc_pygeoapi/loader/climate_archive.py
@@ -950,7 +950,7 @@ class ClimateArchiveLoader(BaseLoader):
 
 @click.group()
 def climate_archive():
-    """Manages Cliamte Archive indices"""
+    """Manages climate archive indices"""
     pass
 
 

--- a/msc_pygeoapi/loader/hydrometric_realtime.py
+++ b/msc_pygeoapi/loader/hydrometric_realtime.py
@@ -484,13 +484,26 @@ def cache_stations(ctx):
     default=DAYS_TO_KEEP,
     help='Delete indexes older than n days (default={})'
 )
+@cli_options.OPTION_ELASTICSEARCH()
+@cli_options.OPTION_ES_USERNAME()
+@cli_options.OPTION_ES_PASSWORD()
 @cli_options.OPTION_YES(
     prompt='Are you sure you want to delete old indexes?'
 )
-def clean_indexes(ctx, days):
-    """Delete old indexes"""
+def clean_indexes(ctx, days, es, username, password):
+    """Clean hydrometric realtime indexes older than n number of days"""
 
-    es = get_es(MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH)
+    # if es, username and and password passed, use to create ES connection
+    if all([es, username, password]):
+        es_conn_dict = {
+            'host': es,
+            'auth': (username, password)
+        }
+        es = get_es(es_conn_dict['host'], es_conn_dict['auth'])
+    # otherwise use environment variables
+    else:
+        es_conn_dict = {}
+        es = get_es(MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH)
 
     indexes = list(es.indices.get('{}*'.format(INDEX_BASENAME)).keys())
 
@@ -498,23 +511,34 @@ def clean_indexes(ctx, days):
         indexes_to_delete = check_es_indexes_to_delete(indexes, days)
         if indexes_to_delete:
             click.echo('Deleting indexes {}'.format(indexes_to_delete))
-            delete_es_indexes(','.join(indexes))
+            delete_es_indexes(','.join(indexes), conn_dict=es_conn_dict)
 
     click.echo('Done')
 
 
 @click.command()
 @click.pass_context
+@cli_options.OPTION_ELASTICSEARCH()
+@cli_options.OPTION_ES_USERNAME()
+@cli_options.OPTION_ES_PASSWORD()
 @cli_options.OPTION_YES(
     prompt='Are you sure you want to delete these indexes?'
 )
-def delete_indexes(ctx):
-    """Delete all hydrometric realtime indexes"""
+def delete_indexes(ctx, es, username, password):
+    """Delete all hydrometric realtime indexe"""
 
     all_indexes = '{}*'.format(INDEX_BASENAME)
 
     click.echo('Deleting indexes {}'.format(all_indexes))
-    delete_es_indexes(all_indexes)
+
+    if all([es, username, password]):
+        es_conn_dict = {
+            'host': es,
+            'auth': (username, password)
+        }
+        delete_es_indexes(all_indexes, conn_dict=es_conn_dict)
+    else:
+        delete_es_indexes(all_indexes)
 
     click.echo('Done')
 

--- a/msc_pygeoapi/util.py
+++ b/msc_pygeoapi/util.py
@@ -254,12 +254,12 @@ def check_es_indexes_to_delete(indexes, days):
     return to_delete
 
 
-def delete_es_indexes(indexes):
+def delete_es_indexes(indexes, conn_dict={}):
     """
     helper function to delete a series of ES indexes
-
     :param indexes: indexes to delete
-
+    :param conn_dict: `dict` containing a host key and a auth key comprised of
+                      a tuple containing username and password.
     :returns: None
     """
 
@@ -268,7 +268,12 @@ def delete_es_indexes(indexes):
         LOGGER.error(msg)
         raise ValueError(msg)
 
-    es = get_es(MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH)
+    # if a non-empty conn_dict kwarg was passed in call, use to connect to ES
+    if conn_dict:
+        es = get_es(conn_dict['host'], conn_dict['auth'])
+    # otherwise use environment variables
+    else:
+        es = get_es(MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH)
 
     if es.indices.exists(indexes):
         LOGGER.info('Deleting indexes {}'.format(indexes))


### PR DESCRIPTION
Adds the ability to pass flags defining the Elasticsearch host, username and password to use when calling the `delete-indexes` and `clean-indexes` commands. This allows to call the commands via the CLI without being limited to the values held in the various MSC_PYGEOAPI_ES environment variables.