### PR TITLE
add Elasticsearch connector

### DIFF
--- a/msc_pygeoapi/cli_options.py
+++ b/msc_pygeoapi/cli_options.py
@@ -38,7 +38,7 @@ def OPTION_DATASET(*args, **kwargs):
 
     default_kwargs = {
         'required': True,
-        'help': 'ES dataset to load, or all if loading everything',
+        'help': 'Dataset to load, or all if loading everything',
     }
 
     if not args:
@@ -79,7 +79,7 @@ def OPTION_DB(*args, **kwargs):
 
 def OPTION_DIRECTORY(*args, **kwargs):
 
-    default_args = ['--directory', '-d', 'directory_']
+    default_args = ['--directory', '-d']
 
     default_kwargs = {
         'type': click.Path(exists=True, resolve_path=True),
@@ -141,6 +141,18 @@ def OPTION_ES_USERNAME(*args, **kwargs):
     kwargs = {**default_kwargs, **kwargs} if kwargs else default_kwargs
 
     return click.option(*args, **kwargs)
+
+
+def OPTION_ES_IGNORE_CERTS(**kwargs):
+
+    default_kwargs = {
+        'is_flag': True,
+        'help': 'Ignore certificate verification when connecting to ES'
+    }
+
+    kwargs = {**default_kwargs, **kwargs} if kwargs else default_kwargs
+
+    return click.option('--ignore-certs', **kwargs)
 
 
 def OPTION_FILE(*args, **kwargs):

--- a/msc_pygeoapi/connector/__init__.py
+++ b/msc_pygeoapi/connector/__init__.py
@@ -1,8 +1,8 @@
 # =================================================================
 #
-# Author: Tom Kralidis <tom.kralidis@canada.ca>
+# Author: Etienne <etienne.pelletier@canada.ca>
 #
-# Copyright (c) 2020 Tom Kralidis
+# Copyright (c) 2021 Etienne Pelletier
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -26,15 +26,3 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # =================================================================
-
-# every day at 0300h, clean bulletin records from ES
-#0 3 * * * geoadm msc-pygeoapi data bulletins clean-indexes --yes
-
-# every day at 0400h, clean hydrometric realtime data older than 30 days
-0 4 * * * geoadm msc-pygeoapi data hydrometric-realtime clean-indexes --days 30
-
-# every day at 0500h, clean swob realtime data older than 30 days
-0 5 * * * geoadm msc-pygeoapi data swob-realtime clean-indexes --days 30
-
-# every day at 0300h, clean out empty MetPX directories
-0 3 * * * geoadm /usr/bin/find $MSC_PYGEOAPI_CACHEDIR -type d -empty -delete > /dev/null 2>&1

--- a/msc_pygeoapi/connector/base.py
+++ b/msc_pygeoapi/connector/base.py
@@ -1,8 +1,8 @@
 # =================================================================
 #
-# Author: Tom Kralidis <tom.kralidis@canada.ca>
+# Author: Etienne <etienne.pelletier@canada.ca>
 #
-# Copyright (c) 2020 Tom Kralidis
+# Copyright (c) 2021 Etienne Pelletier
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -27,14 +27,48 @@
 #
 # =================================================================
 
-# every day at 0300h, clean bulletin records from ES
-#0 3 * * * geoadm msc-pygeoapi data bulletins clean-indexes --yes
+import logging
 
-# every day at 0400h, clean hydrometric realtime data older than 30 days
-0 4 * * * geoadm msc-pygeoapi data hydrometric-realtime clean-indexes --days 30
+LOGGER = logging.getLogger(__name__)
 
-# every day at 0500h, clean swob realtime data older than 30 days
-0 5 * * * geoadm msc-pygeoapi data swob-realtime clean-indexes --days 30
 
-# every day at 0300h, clean out empty MetPX directories
-0 3 * * * geoadm /usr/bin/find $MSC_PYGEOAPI_CACHEDIR -type d -empty -delete > /dev/null 2>&1
+class BaseConnector:
+    """generic Connector ABC"""
+
+    def __init__(self, connector_def):
+        """
+        Initialize BaseConnector object
+
+        :param connector_def: connector definition
+
+        :returns: msc_pygeoapi.connector.base.BaseConnector
+        """
+
+    def connect(self):
+        """
+        Create connection to connector
+        """
+
+    def create(self):
+        """
+        Create a connector resource
+        """
+
+        raise NotImplementedError
+
+    def get(self):
+        """
+        Retrieve connector resources
+        """
+
+        raise NotImplementedError
+
+    def delete(self):
+        """
+        Delete connector resource(s)
+        """
+
+        raise NotImplementedError
+
+    def __repr__(self):
+        return '<BaseConnector> {}'.format(self.name)

--- a/msc_pygeoapi/connector/elasticsearch_.py
+++ b/msc_pygeoapi/connector/elasticsearch_.py
@@ -1,0 +1,255 @@
+# =================================================================
+#
+# Author: Etienne <etienne.pelletier@canada.ca>
+#
+# Copyright (c) 2021 Etienne Pelletier
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+import logging
+from urllib.parse import urlparse
+
+from elasticsearch import Elasticsearch
+from elasticsearch.helpers import streaming_bulk, BulkIndexError
+
+from msc_pygeoapi.connector.base import BaseConnector
+from msc_pygeoapi.env import (
+    MSC_PYGEOAPI_ES_USERNAME,
+    MSC_PYGEOAPI_ES_PASSWORD,
+    MSC_PYGEOAPI_ES_URL,
+    MSC_PYGEOAPI_ES_TIMEOUT,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ElasticsearchConnector(BaseConnector):
+    """Elasticsearch Connector"""
+
+    def __init__(self, connector_def={}):
+        """
+        Elasticticsearch connection initialization
+
+        :param connector_def: connection definition dictionnary
+
+        :returns: msc_pygeoapi.connector.elasticsearch_.ElasticsearchConnector
+        """
+
+        self.url = connector_def.get('url', MSC_PYGEOAPI_ES_URL)
+
+        # if no URL passed in connector def or env variable not set default
+        # to default ES port on localhost
+        if not self.url:
+            self.url = 'http://localhost:9200'
+
+        self.verify_certs = connector_def.get('verify_certs', True)
+
+        if 'auth' in connector_def:
+            self.auth = connector_def['auth']
+        elif all([MSC_PYGEOAPI_ES_USERNAME, MSC_PYGEOAPI_ES_PASSWORD]):
+            self.auth = (MSC_PYGEOAPI_ES_USERNAME, MSC_PYGEOAPI_ES_PASSWORD)
+        else:
+            self.auth = None
+
+        self.Elasticsearch = self.connect()
+
+    def connect(self):
+        """create Elasticsearch connection"""
+
+        LOGGER.debug('Connecting to Elasticsearch')
+
+        # if no protocol specified in url append http:// by default
+        if not self.url.startswith('http'):
+            self.url = 'http://{}'.format(self.url)
+
+        url_parsed = urlparse(self.url)
+        url_settings = {'host': url_parsed.hostname}
+
+        if url_parsed.port is None:  # proxy to default HTTP(S) port
+            if url_parsed.scheme == 'https':
+                url_settings['port'] = 443
+                url_settings['scheme'] = url_parsed.scheme
+            else:
+                url_settings['port'] = 80
+        else:  # was set explictly
+            url_settings['port'] = url_parsed.port
+
+        if url_parsed.path:
+            url_settings['url_prefix'] = url_parsed.path
+
+        LOGGER.debug('URL settings: {}'.format(url_settings))
+
+        if self.auth:
+            return Elasticsearch(
+                [url_settings],
+                http_auth=self.auth,
+                verify_certs=self.verify_certs,
+            )
+        else:
+            return Elasticsearch(
+                [url_settings], verify_certs=self.verify_certs
+            )
+
+    def create(self, index_name, mapping, overwrite=False):
+        """
+        create an Elaticsearch index
+
+        :param index_name: name of in index to create
+        :mapping: `dict` mapping of index to create
+        :overwrite: `bool` indicating whether to overwrite index if it already
+                    exists
+
+        :returns: `bool` of creation status
+        """
+
+        # if overwrite is False, do not recreate an existing index
+        if self.Elasticsearch.indices.exists(index_name) and not overwrite:
+            LOGGER.info('{} index already exists.')
+            return False
+
+        elif self.Elasticsearch.indices.exists(index_name) and overwrite:
+            self.Elasticsearch.indices.delete(index_name)
+            LOGGER.info('Deleted existing {} index.'.format(index_name))
+
+        self.Elasticsearch.indices.create(
+            index=index_name,
+            body=mapping,
+            request_timeout=MSC_PYGEOAPI_ES_TIMEOUT,
+        )
+
+        return True
+
+    def get(self, pattern):
+        """
+        get list of Elaticsearch index matching a pattern
+
+        :param pattern: `str` of pattern to match
+
+        :returns: `list` of index names matching patterns
+        """
+
+        return list(self.Elasticsearch.indices.get(pattern).keys())
+
+    def delete(self, indexes):
+        """
+        delete ES index(es)
+
+        :param indexes: indexes to delete, comma-seperated if multiple.
+
+        :returns: `bool` of deletion status
+        """
+
+        if indexes in ['*', '_all'] or not self.Elasticsearch.indices.exists(
+            indexes
+        ):
+            msg = (
+                'Cannot delete {}. '.format(indexes),
+                'Either the index does not exist or an unaccepted index ',
+                'pattern was given (\'*\' or \'_all\')',
+            )
+            LOGGER.error(msg)
+            raise ValueError(msg)
+
+        LOGGER.info('Deleting indexes {}'.format(indexes))
+        self.Elasticsearch.indices.delete(indexes)
+
+        return True
+
+    def create_template(self, name, settings):
+        """
+        create an Elasticsearch index template
+
+        :param name: `str` index template name
+        :param settings: `dict` settings dictionnary for index template
+
+        :return: `bool` of index template creation status
+        """
+
+        if not self.Elasticsearch.indices.exists_template(name):
+            self.Elasticsearch.indices.put_template(name, settings)
+
+        return True
+
+    def submit_elastic_package(self, package, request_size=10000):
+        """
+        helper function to send an update request to Elasticsearch and
+        log the status of the request. Returns True if the upload succeeded.
+
+        :param package: Iterable of bulk API update actions.
+        :param request_size: Number of documents to upload per request.
+
+        :returns: `bool` of whether the operation was successful.
+        """
+
+        inserts = 0
+        updates = 0
+        noops = 0
+        errors = []
+
+        try:
+            for ok, response in streaming_bulk(
+                self.Elasticsearch,
+                package,
+                chunk_size=request_size,
+                request_timeout=30,
+                raise_on_error=False,
+            ):
+                if not ok:
+                    errors.append(response)
+                else:
+                    status = response['update']['result']
+
+                    if status == 'created':
+                        inserts += 1
+                    elif status == 'updated':
+                        updates += 1
+                    elif status == 'noop':
+                        noops += 1
+                    else:
+                        LOGGER.error('Unhandled status code {}'.format(status))
+                        errors.append(response)
+        except BulkIndexError as err:
+            LOGGER.error(
+                'Unable to perform bulk insert due to: {}'.format(err.errors)
+            )
+            return False
+
+        total = inserts + updates + noops
+        LOGGER.info(
+            'Inserted package of {} documents ({} inserts, {} updates,'
+            ' {} no-ops)'.format(total, inserts, updates, noops)
+        )
+
+        if len(errors) > 0:
+            LOGGER.warning(
+                '{} errors encountered in bulk insert: {}'.format(
+                    len(errors), errors
+                )
+            )
+            return False
+
+        return True
+
+    def __repr__(self):
+        return '<ElasticsearchConnector> {}'.format(self.url)

--- a/msc_pygeoapi/loader/cap_alerts_realtime.py
+++ b/msc_pygeoapi/loader/cap_alerts_realtime.py
@@ -36,11 +36,14 @@ import os
 import re
 
 from msc_pygeoapi import cli_options
-from msc_pygeoapi.env import (MSC_PYGEOAPI_ES_TIMEOUT, MSC_PYGEOAPI_ES_URL,
-                              MSC_PYGEOAPI_ES_AUTH)
+from msc_pygeoapi.connector.elasticsearch_ import ElasticsearchConnector
 from msc_pygeoapi.loader.base import BaseLoader
-from msc_pygeoapi.util import (get_es, json_pretty_print, _get_date_format,
-                               _get_element)
+from msc_pygeoapi.util import (
+    configure_es_connection,
+    json_pretty_print,
+    _get_date_format,
+    _get_element,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -175,17 +178,13 @@ SETTINGS = {
 class CapAlertsRealtimeLoader(BaseLoader):
     """Cap Alerts real-time loader"""
 
-    def __init__(self, plugin_def):
+    def __init__(self, conn_config={}):
         """initializer"""
 
         BaseLoader.__init__(self)
 
-        self.ES = get_es(MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH)
-
-        if not self.ES.indices.exists(INDEX_NAME,
-                                      request_timeout=MSC_PYGEOAPI_ES_TIMEOUT):
-            self.ES.indices.create(index=INDEX_NAME, body=SETTINGS,
-                                   request_timeout=MSC_PYGEOAPI_ES_TIMEOUT)
+        self.conn = ElasticsearchConnector(conn_config)
+        self.conn.create(INDEX_NAME, mapping=SETTINGS)
 
     def load_data(self, filepath):
         """
@@ -210,7 +209,9 @@ class CapAlertsRealtimeLoader(BaseLoader):
                 op_dict['index']['_id'] = doc['properties']['identifier']
                 self.bulk_data.append(op_dict)
                 self.bulk_data.append(doc)
-            r = self.ES.bulk(index=INDEX_NAME, body=self.bulk_data)
+            r = self.conn.Elasticsearch.bulk(
+                index=INDEX_NAME, body=self.bulk_data
+            )
 
             LOGGER.debug('Result: {}'.format(r))
 
@@ -233,8 +234,6 @@ class CapAlertsRealtimeLoader(BaseLoader):
 
         if self.references_arr and len(self.references_arr) != 0:
 
-            es = get_es(MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH)
-
             click.echo('Deleting old alerts')
 
             query = {
@@ -245,7 +244,9 @@ class CapAlertsRealtimeLoader(BaseLoader):
                 }
             }
 
-            es.delete_by_query(index=INDEX_NAME, body=query)
+            self.conn.Elasticsearch.delete_by_query(
+                index=INDEX_NAME, body=query
+            )
 
             return True
 
@@ -462,11 +463,17 @@ def cap_alerts():
 @click.pass_context
 @cli_options.OPTION_FILE()
 @cli_options.OPTION_DIRECTORY()
-def add(ctx, file_, directory):
+@cli_options.OPTION_ELASTICSEARCH()
+@cli_options.OPTION_ES_USERNAME()
+@cli_options.OPTION_ES_PASSWORD()
+@cli_options.OPTION_ES_IGNORE_CERTS()
+def add(ctx, file_, directory, es, username, password, ignore_certs):
     """add data to system"""
 
     if all([file_ is None, directory is None]):
         raise click.ClickException('Missing --file/-f or --dir/-d option')
+
+    conn_config = configure_es_connection(es, username, password, ignore_certs)
 
     files_to_process = []
 
@@ -479,11 +486,7 @@ def add(ctx, file_, directory):
         files_to_process.sort(key=os.path.getmtime)
 
     for file_to_process in files_to_process:
-        plugin_def = {
-            'filename_pattern': 'alerts/cap',
-            'handler': 'msc_pygeoapi.loader.cap_alerts.CapAlertsRealtimeLoader'  # noqa
-        }
-        loader = CapAlertsRealtimeLoader(plugin_def)
+        loader = CapAlertsRealtimeLoader(conn_config)
         result = loader.load_data(file_to_process)
         if result:
             click.echo('GeoJSON features generated: {}'.format(
@@ -496,16 +499,21 @@ def add(ctx, file_, directory):
     default=DAYS_TO_KEEP,
     help=f'Delete documents older than n days (default={DAYS_TO_KEEP})'
 )
+@cli_options.OPTION_ELASTICSEARCH()
+@cli_options.OPTION_ES_USERNAME()
+@cli_options.OPTION_ES_PASSWORD()
+@cli_options.OPTION_ES_IGNORE_CERTS()
 @cli_options.OPTION_YES(
     prompt='Are you sure you want to delete old documents?'
 )
-def clean_records(ctx, days):
-    """Delete old documents"""
+def clean_records(ctx, days, es, username, password, ignore_certs):
+    """Delete old cap-alerts documents"""
 
-    es = get_es(MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH)
+    conn_config = configure_es_connection(es, username, password, ignore_certs)
+    conn = ElasticsearchConnector(conn_config)
 
     older_than = (datetime.now() - timedelta(days=days)).strftime(
-        '%Y-%m-%d %H:%M')
+        '%Y-%m-%dT%H:%M:%SZ')
     click.echo('Deleting documents older than {} ({} days)'.format(
         older_than, days))
 
@@ -519,21 +527,25 @@ def clean_records(ctx, days):
         }
     }
 
-    es.delete_by_query(index=INDEX_NAME, body=query)
+    conn.Elasticsearch.delete_by_query(index=INDEX_NAME, body=query)
 
 
 @click.command()
 @click.pass_context
+@cli_options.OPTION_ELASTICSEARCH()
+@cli_options.OPTION_ES_USERNAME()
+@cli_options.OPTION_ES_PASSWORD()
+@cli_options.OPTION_ES_IGNORE_CERTS()
 @cli_options.OPTION_YES(
     prompt='Are you sure you want to delete this index?'
 )
-def delete_index(ctx):
-    """Delete current conditions index"""
+def delete_index(ctx, es, username, password, ignore_certs):
+    """Delete cap-alerts realtime index"""
 
-    es = get_es(MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH)
+    conn_config = configure_es_connection(es, username, password, ignore_certs)
+    conn = ElasticsearchConnector(conn_config)
 
-    if es.indices.exists(INDEX_NAME):
-        es.indices.delete(INDEX_NAME)
+    conn.delete(INDEX_NAME)
 
 
 cap_alerts.add_command(add)

--- a/msc_pygeoapi/loader/marine_weather_realtime.py
+++ b/msc_pygeoapi/loader/marine_weather_realtime.py
@@ -34,16 +34,22 @@ import os
 from pathlib import Path
 
 import click
-from elasticsearch import helpers, exceptions, logger as elastic_logger
+from elasticsearch import exceptions, logger as elastic_logger
 from lxml import etree
 from parse import parse
 
 from msc_pygeoapi import cli_options
-from msc_pygeoapi.env import (MSC_PYGEOAPI_BASEPATH, MSC_PYGEOAPI_ES_TIMEOUT,
-                              MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH,
-                              MSC_PYGEOAPI_LOGGING_LOGLEVEL)
+from msc_pygeoapi.connector.elasticsearch_ import ElasticsearchConnector
+from msc_pygeoapi.env import (
+    MSC_PYGEOAPI_BASEPATH,
+    MSC_PYGEOAPI_LOGGING_LOGLEVEL,
+)
 from msc_pygeoapi.loader.base import BaseLoader
-from msc_pygeoapi.util import get_es, json_pretty_print, strftime_rfc3339
+from msc_pygeoapi.util import (
+    configure_es_connection,
+    json_pretty_print,
+    strftime_rfc3339,
+)
 
 LOGGER = logging.getLogger(__name__)
 elastic_logger.setLevel(getattr(logging, MSC_PYGEOAPI_LOGGING_LOGLEVEL))
@@ -320,12 +326,12 @@ INDICES = [INDEX_NAME.format(weather_var) for weather_var in MAPPINGS]
 class MarineWeatherRealtimeLoader(BaseLoader):
     """Marine weather real-time loader"""
 
-    def __init__(self, plugin_def):
+    def __init__(self, conn_config={}):
         """initializer"""
 
         BaseLoader.__init__(self)
 
-        self.ES = get_es(MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH)
+        self.conn = ElasticsearchConnector(conn_config)
         self.filepath = None
         self.region_name_code = None
         self.language = None
@@ -335,18 +341,10 @@ class MarineWeatherRealtimeLoader(BaseLoader):
 
         # create marine weather indices if it don't exist
         for item in MAPPINGS:
-            if not self.ES.indices.exists(INDEX_NAME.format(item)):
-                SETTINGS['mappings']['properties']['properties'][
-                    'properties'
-                ] = MAPPINGS[
-                    item
-                ]  # noqa
-
-                self.ES.indices.create(
-                    index=INDEX_NAME.format(item),
-                    body=SETTINGS,
-                    request_timeout=MSC_PYGEOAPI_ES_TIMEOUT,
-                )
+            SETTINGS['mappings']['properties']['properties'][
+                'properties'
+            ] = MAPPINGS[item]
+            self.conn.create(INDEX_NAME.format(item), SETTINGS)
 
     def parse_filename(self):
         """
@@ -412,7 +410,7 @@ class MarineWeatherRealtimeLoader(BaseLoader):
             forecast_id = meteocode_lookup[self.region_name_code]
 
         try:
-            result = self.ES.get(
+            result = self.conn.Elasticsearch.get(
                 index='forecast_polygons_water_detail',
                 id=forecast_id,
                 _source=['geometry'],
@@ -705,13 +703,7 @@ class MarineWeatherRealtimeLoader(BaseLoader):
         self.filepath = Path(filepath)
         self.parse_filename()
 
-        inserts = 0
-        updates = 0
-        noops = 0
-        fails = 0
-
         LOGGER.debug('Received file {}'.format(self.filepath))
-        chunk_size = 80000
 
         self.root = etree.parse(str(self.filepath.resolve())).getroot()
 
@@ -723,31 +715,7 @@ class MarineWeatherRealtimeLoader(BaseLoader):
         extended_forecasts = self.generate_extended_forecasts()
 
         for package in [warnings, regular_forecasts, extended_forecasts]:
-            for ok, response in helpers.streaming_bulk(
-                self.ES,
-                package,
-                chunk_size=chunk_size,
-                # noqa
-                request_timeout=30,
-            ):
-                status = response['update']['result']
-
-                if status == 'created':
-                    inserts += 1
-                elif status == 'updated':
-                    updates += 1
-                elif status == 'noop':
-                    noops += 1
-                else:
-                    LOGGER.warning('Unhandled status code {}'.format(status))
-
-        total = inserts + updates + noops + fails
-        LOGGER.info(
-            'Inserted package of {}  ({} '
-            'inserts, {} updates, {} no-ops, {} rejects)'.format(
-                total, inserts, updates, noops, fails
-            )
-        )
+            self.conn.submit_elastic_package(package, request_size=80000)
         return True
 
 
@@ -761,11 +729,17 @@ def marine_weather():
 @click.pass_context
 @cli_options.OPTION_FILE()
 @cli_options.OPTION_DIRECTORY()
-def add(ctx, file_, directory):
+@cli_options.OPTION_ELASTICSEARCH()
+@cli_options.OPTION_ES_USERNAME()
+@cli_options.OPTION_ES_PASSWORD()
+@cli_options.OPTION_ES_IGNORE_CERTS()
+def add(ctx, file_, directory, es, username, password, ignore_certs):
     """add data to system"""
 
     if all([file_ is None, directory is None]):
         raise click.ClickException('Missing --file/-f or --dir/-d option')
+
+    conn_config = configure_es_connection(es, username, password, ignore_certs)
 
     files_to_process = []
 
@@ -778,11 +752,7 @@ def add(ctx, file_, directory):
         files_to_process.sort(key=os.path.getmtime)
 
     for file_to_process in files_to_process:
-        plugin_def = {
-            'filename_pattern': 'marine_weather/xml',
-            'handler': 'msc_pygeoapi.loader.marine_weather_realtime.MarineWeatherRealtimeLoader',  # noqa
-        }
-        loader = MarineWeatherRealtimeLoader(plugin_def)
+        loader = MarineWeatherRealtimeLoader(conn_config)
         result = loader.load_data(file_to_process)
         if result:
             click.echo(
@@ -795,12 +765,19 @@ def add(ctx, file_, directory):
 @click.command()
 @click.pass_context
 @cli_options.OPTION_INDEX_NAME(type=click.Choice(INDICES))
-def delete_index(ctx, index_name):
+@cli_options.OPTION_ELASTICSEARCH()
+@cli_options.OPTION_ES_USERNAME()
+@cli_options.OPTION_ES_PASSWORD()
+@cli_options.OPTION_ES_IGNORE_CERTS()
+def delete_index(ctx, index_name, es, username, password, ignore_certs):
     """
     Delete a particular ES index with a given name as argument or all if no
     argument is passed
     """
-    es = get_es(MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH)
+
+    conn_config = configure_es_connection(es, username, password, ignore_certs)
+    conn = ElasticsearchConnector(conn_config)
+
     if index_name:
         if click.confirm(
             'Are you sure you want to delete ES index named: {}?'.format(
@@ -809,7 +786,7 @@ def delete_index(ctx, index_name):
             abort=True,
         ):
             LOGGER.info('Deleting ES index {}'.format(index_name))
-            es.indices.delete(index=index_name)
+            conn.delete(index_name)
             return True
     else:
         if click.confirm(
@@ -820,7 +797,7 @@ def delete_index(ctx, index_name):
             ),
             abort=True,
         ):
-            es.indices.delete(index=",".join(INDICES))
+            conn.delete(",".join(INDICES))
             return True
 
 

--- a/msc_pygeoapi/plugin.py
+++ b/msc_pygeoapi/plugin.py
@@ -70,7 +70,7 @@ PLUGINS = {
 }
 
 
-def load_plugin(plugin_type, plugin_def):
+def load_plugin(plugin_type, plugin_def, **kwargs):
     """
     loads plugin by type
 

--- a/msc_pygeoapi/util.py
+++ b/msc_pygeoapi/util.py
@@ -30,115 +30,14 @@
 from datetime import datetime, date, time, timedelta
 import json
 import logging
-from urllib.parse import urlparse
 
-from elasticsearch import Elasticsearch
-from elasticsearch.helpers import streaming_bulk, BulkIndexError
 from parse import parse
 
-from msc_pygeoapi.env import MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH
 
 LOGGER = logging.getLogger(__name__)
 
-VERIFY = False
-
 DATETIME_RFC3339_FMT = '%Y-%m-%dT%H:%M:%SZ'
 DATETIME_RFC3339_MILLIS_FMT = '%Y-%m-%dT%H:%M:%S.%fZ'
-
-
-def get_es(url, auth=None):
-    """
-    helper function to instantiate an Elasticsearch connection
-
-    :param url: URL of ES endpoint
-    :param auth: HTTP username-password tuple for authentication (optional)
-    :returns: `elasticsearch.Elasticsearch` object
-    """
-
-    url_parsed = urlparse(url)
-    url_settings = {
-        'host': url_parsed.hostname
-    }
-
-    LOGGER.debug('Connecting to Elasticsearch')
-
-    if url_parsed.port is None:  # proxy to default HTTP(S) port
-        if url_parsed.scheme == 'https':
-            url_settings['port'] = 443
-            url_settings['scheme'] = url_parsed.scheme
-        else:
-            url_settings['port'] = 80
-    else:  # was set explictly
-        url_settings['port'] = url_parsed.port
-
-    if url_parsed.path:
-        url_settings['url_prefix'] = url_parsed.path
-
-    LOGGER.debug('URL settings: {}'.format(url_settings))
-
-    if auth is None:
-        es = Elasticsearch([url_settings], verify_certs=VERIFY)
-    else:
-        es = Elasticsearch([url_settings], http_auth=auth, verify_certs=VERIFY)
-
-    if not es.ping():
-        msg = 'Cannot connect to Elasticsearch'
-        LOGGER.error(msg)
-        raise RuntimeError(msg)
-
-    return es
-
-
-def submit_elastic_package(es, package, request_size=10000):
-    """
-    Helper function to send an update request to Elasticsearch and
-    log the status of the request. Returns True iff the upload succeeded.
-
-    :param es: Elasticsearch client object.
-    :param package: Iterable of bulk API update actions.
-    :param request_size: Number of documents to upload per request.
-    :returns: `bool` of whether the operation was successful.
-    """
-
-    inserts = 0
-    updates = 0
-    noops = 0
-    errors = []
-
-    try:
-        for ok, response in streaming_bulk(es, package,
-                                           chunk_size=request_size,
-                                           request_timeout=30,
-                                           raise_on_error=False):
-            if not ok:
-                errors.append(response)
-            else:
-                status = response['update']['result']
-
-                if status == 'created':
-                    inserts += 1
-                elif status == 'updated':
-                    updates += 1
-                elif status == 'noop':
-                    noops += 1
-                else:
-                    LOGGER.error('Unhandled status code {}'.format(status))
-                    errors.append(response)
-    except BulkIndexError as err:
-        LOGGER.error('Unable to perform bulk insert due to: {}'
-                     .format(err.errors))
-        return False
-
-    total = inserts + updates + noops
-    LOGGER.info('Inserted package of {} observations ({} inserts, {} updates,'
-                ' {} no-ops'.format(total, inserts, updates, noops))
-
-    if len(errors) > 0:
-        LOGGER.warning('{} errors encountered in bulk insert: {}'.format(
-            len(errors), errors))
-        return False
-
-    return True
 
 
 def click_abort_if_false(ctx, param, value):
@@ -246,30 +145,38 @@ def check_es_indexes_to_delete(indexes, days):
 
     for index in indexes:
         parsed = parse(pattern, index)
-        index_date = datetime(parsed.named['YYYY'], parsed.named['MM'],
-                              parsed.named['dd'])
+        index_date = datetime(
+            parsed.named['YYYY'], parsed.named['MM'], parsed.named['dd']
+        )
         if index_date < (today - timedelta(days=days)):
             to_delete.append(index)
 
     return to_delete
 
 
-def delete_es_indexes(indexes):
+def configure_es_connection(
+    es: str, username: str, password: str, ignore_certs: bool = False
+) -> dict:
     """
-    helper function to delete a series of ES indexes
+    helper function to create an ES connection configuration dictionnary with
+    the relevant params passed via CLI.
 
-    :param indexes: indexes to delete
+    :param es: `str` ES url
+    :param username: `str` ES username for authentication
+    :param password: `str` ES password for authentication
+    :param ignore_certs: `bool` indicates whether to ignore certs when
+                         connecting. Defaults to False.
 
-    :returns: None
+    :returns: `dict` containing ES connection configuration
     """
+    conn_config = {}
 
-    if indexes in ['*', '_all']:
-        msg = 'Cannot delete {}'.format(indexes)
-        LOGGER.error(msg)
-        raise ValueError(msg)
+    if es:
+        conn_config['url'] = es
+    if all([username, password]):
+        conn_config['auth'] = (username, password)
 
-    es = get_es(MSC_PYGEOAPI_ES_URL, MSC_PYGEOAPI_ES_AUTH)
+    # negate ignore_certs CLI flag value to get verify_certs value
+    conn_config['verify_certs'] = not ignore_certs
 
-    if es.indices.exists(indexes):
-        LOGGER.info('Deleting indexes {}'.format(indexes))
-        es.indices.delete(indexes)
+    return conn_config


### PR DESCRIPTION
This MR adds an `msc_pygeoapi.connector.base.BaseConnector` class as well as an `msc_pygeoapi.connector.elasticsearch_.ElasticsearchConnector` class in order to streamline the ES connections and various tasks performed throughout all loaders.

When instantiating an `ElasticsearchConnector()` object, a dictionary with connection configuration is passed. If the configuration contained in the dictionary is incomplete, the connector uses environment variables to substitute for missing values, ultimately trying to connect to localhost:9200 if no environment variables are available.

This allows for the following situation to happen:

- Pass ES connection information via CLI (username, password, host)
- If one or more of these items is not passed, use environment variables for ES host, username and password.
- If ES auth environment variables not set, attempt to connect without auth to MSC_PYGEOAPI_ES_URL.
- If MSC_PYGEOAPI_ES_URL is not set, attempt to connect to default ES port on localhost.

All CLI commands for loaders can now be passed ES auth and url parameters. Furthermore, certificate verification can now be turned off via the `--ignore-certs` flag instead of being set in the code itself. By default, certificate verification is enabled unless specified otherwise in the CLI command.

Also contained in this MR:
- fix incorrect commands in `debian/msc-pygeoapi.cron.d`.
- Minor CLI typo fixes.
- Rename `clean-index` command to `clean-indexes` for loaders that control multiple ES indexes.
- Updated `forecast_polygons` to ingest newest version (6.4.0).
- Datetime fix for cap-alerts-realtime when deleting documents older than a given date.

I have tested all loaders against local data and realtime loaders against AMQP feeds.

