### PR TITLE
update hydrometric realtime mappings, add index template deletion option

### DIFF
--- a/msc_pygeoapi/cli_options.py
+++ b/msc_pygeoapi/cli_options.py
@@ -189,6 +189,23 @@ def OPTION_INDEX_NAME(*args, **kwargs):
     return click.option(*args, **kwargs)
 
 
+def OPTION_INDEX_TEMPLATE(*args, **kwargs):
+
+    default_args = ['--index-template', '-it']
+
+    default_kwargs = {
+        'is_flag': True,
+        'help': 'include index templates'
+    }
+
+    if not args:
+        args = default_args
+
+    kwargs = {**default_kwargs, **kwargs} if kwargs else default_kwargs
+
+    return click.option(*args, **kwargs)
+
+
 def OPTION_YES(**kwargs):
 
     default_kwargs = {

--- a/msc_pygeoapi/connector/elasticsearch_.py
+++ b/msc_pygeoapi/connector/elasticsearch_.py
@@ -191,6 +191,20 @@ class ElasticsearchConnector(BaseConnector):
 
         return True
 
+    def delete_template(self, name):
+        """
+        delete an Elasticsearch index template
+
+        :param name: `str` index template name
+
+        :return: `bool` of index template creation status
+        """
+
+        if self.Elasticsearch.indices.exists_template(name):
+            self.Elasticsearch.indices.delete_template(name)
+
+        return True
+
     def submit_elastic_package(self, package, request_size=10000):
         """
         helper function to send an update request to Elasticsearch and

--- a/msc_pygeoapi/connector/elasticsearch_.py
+++ b/msc_pygeoapi/connector/elasticsearch_.py
@@ -197,7 +197,7 @@ class ElasticsearchConnector(BaseConnector):
 
         :param name: `str` index template name
 
-        :return: `bool` of index template creation status
+        :return: `bool` of index template deletion status
         """
 
         if self.Elasticsearch.indices.exists_template(name):

--- a/msc_pygeoapi/loader/bulletins.py
+++ b/msc_pygeoapi/loader/bulletins.py
@@ -216,10 +216,11 @@ def clean_indexes(ctx, days, es, username, password, ignore_certs):
 @cli_options.OPTION_ES_USERNAME()
 @cli_options.OPTION_ES_PASSWORD()
 @cli_options.OPTION_ES_IGNORE_CERTS()
+@cli_options.OPTION_INDEX_TEMPLATE()
 @cli_options.OPTION_YES(
     prompt='Are you sure you want to delete these indexes?'
 )
-def delete_indexes(ctx, es, username, password, ignore_certs):
+def delete_indexes(ctx, es, username, password, ignore_certs, index_template):
     """Delete all hydrometric realtime indexes"""
 
     conn_config = configure_es_connection(es, username, password, ignore_certs)
@@ -229,6 +230,10 @@ def delete_indexes(ctx, es, username, password, ignore_certs):
 
     click.echo('Deleting indexes {}'.format(all_indexes))
     conn.delete(all_indexes)
+
+    if index_template:
+        click.echo('Deleting index template {}'.format(INDEX_BASENAME))
+        conn.delete_template(INDEX_BASENAME)
 
     click.echo('Done')
 

--- a/msc_pygeoapi/loader/hydrometric_realtime.py
+++ b/msc_pygeoapi/loader/hydrometric_realtime.py
@@ -106,6 +106,9 @@ SETTINGS = {
                         'type': 'date',
                         'format': 'strict_date_hour_minute_second'
                     },
+                    'DATETIME_LST': {
+                        'type': 'date',
+                    },
                     'LEVEL': {
                         'type': 'float'
                     },
@@ -351,6 +354,7 @@ class HydrometricRealtimeLoader(BaseLoader):
                         'STATION_NAME': stn_info['STATION_NAME'],
                         'PROV_TERR_STATE_LOC': stn_info['PROV_TERR_STATE_LOC'],
                         'DATETIME': utc_datestamp,
+                        'DATETIME_LST': date,
                         'LEVEL': level,
                         'DISCHARGE': discharge,
                         'LEVEL_SYMBOL_EN': level_symbol_en,
@@ -491,10 +495,11 @@ def clean_indexes(ctx, days, es, username, password, ignore_certs):
 @cli_options.OPTION_ES_USERNAME()
 @cli_options.OPTION_ES_PASSWORD()
 @cli_options.OPTION_ES_IGNORE_CERTS()
+@cli_options.OPTION_INDEX_TEMPLATE()
 @cli_options.OPTION_YES(
     prompt='Are you sure you want to delete these indexes?'
 )
-def delete_indexes(ctx, es, username, password, ignore_certs):
+def delete_indexes(ctx, es, username, password, ignore_certs, index_template):
     """"Delete all hydrometric realtime indexes"""
 
     conn_config = configure_es_connection(es, username, password, ignore_certs)
@@ -504,6 +509,10 @@ def delete_indexes(ctx, es, username, password, ignore_certs):
 
     click.echo('Deleting indexes {}'.format(all_indexes))
     conn.delete(all_indexes)
+
+    if index_template:
+        click.echo('Deleting index template {}'.format(INDEX_BASENAME))
+        conn.delete_template(INDEX_BASENAME)
 
     click.echo('Done')
 

--- a/msc_pygeoapi/loader/swob_realtime.py
+++ b/msc_pygeoapi/loader/swob_realtime.py
@@ -441,10 +441,11 @@ def clean_indexes(ctx, days, es, username, password, ignore_certs):
 @cli_options.OPTION_ES_USERNAME()
 @cli_options.OPTION_ES_PASSWORD()
 @cli_options.OPTION_ES_IGNORE_CERTS()
+@cli_options.OPTION_INDEX_TEMPLATE()
 @cli_options.OPTION_YES(
     prompt='Are you sure you want to delete these indexes?'
 )
-def delete_indexes(ctx, es, username, password, ignore_certs):
+def delete_indexes(ctx, es, username, password, ignore_certs, index_template):
     """Delete all SWOB realtime indexes"""
 
     conn_config = configure_es_connection(es, username, password, ignore_certs)
@@ -454,6 +455,10 @@ def delete_indexes(ctx, es, username, password, ignore_certs):
 
     click.echo('Deleting indexes {}'.format(all_indexes))
     conn.delete(all_indexes)
+
+    if index_template:
+        click.echo('Deleting index template {}'.format(INDEX_BASENAME))
+        conn.delete_template(INDEX_BASENAME)
 
     click.echo('Done')
 


### PR DESCRIPTION
- adds `DATETIME_LST` mapping (for local time, as requested)
- adds `--index-template/-it` boolean flag to `delete-indexes` subcommands to optionally delete index templates.  This is required when we have mapping updates to indexes