### PR TITLE
Progessive enhancement with original Jinja templating

### DIFF
--- a/theme/templates/collections/index.html
+++ b/theme/templates/collections/index.html
@@ -14,17 +14,20 @@
           placeholder="Search"
           v-model="searchText">
       </div>
+
       <table id="collections-table" class="table table-striped">
         <thead>
         <tr>
           <th v-for="(th, index) in tableFields"
             :class="[th.colClass, 'sortable']"
-            @click="sortDir(th.key)">[% th.text %]
+            @click="sortDir(th.key)"><span v-text="th.text">Name</span>
             <span
               v-show="currentSort === th.key"
               :class="sortIconClass"
               class="glyphicon"></span>
           </th>
+          <th v-if="noJs">Type</th>
+          <th v-if="noJs">Description</th>
         </tr>
         </thead>
         <tbody>
@@ -32,13 +35,24 @@
             <td data-label="name">
               <a :title="truncateStripTags(collection.title)"
                 :href="'{{ config['server']['url'] }}/collections/' + collection.id">
-                <span>[% truncateStripTags(collection.title) %]</span></a>
+                <span v-html="truncateStripTags(collection.title)"></span></a>
             </td>
-            <td data-label="type">[% collection.itemType %]</td>
+            <td data-label="type" v-text="collection.itemType"></td>
+            <td data-label="description" v-text="truncateStripTags(collection.description)"></td>
+          </tr>
+          {% for col in data['collections']  %}
+          <tr v-if="noJs">
+            <td data-label="name">
+              <a  title="{{ col['title'] | striptags | truncate }}"
+                href="{{ config['server']['url'] }}/collections/{{ col.id }}">
+                <span>{{ col['title'] | striptags | truncate }}</span></a>
+            </td>
+            <td data-label="type">{{ col["itemType"] }}</td>
             <td data-label="description">
-              [% truncateStripTags(collection.description) %]
+              {{ col['description'] | striptags | truncate }}
             </td>
           </tr>
+          {% endfor %}
         </tbody>
       </table>
     </section>
@@ -55,6 +69,7 @@
       const app = createApp({
         delimiters: ['[%', '%]'],
         setup() {
+          const noJs = ref(false) // progressive enhancement
           const { collections } = useCollections()
 
           // table columns

--- a/theme/templates/collections/items/index.html
+++ b/theme/templates/collections/items/index.html
@@ -52,12 +52,43 @@
                     class="glyphicon"></span>
                 </th>
               </tr>
+              <tr v-if="noJs">
+                {% if data.get('uri_field') %}
+                <th>{{ data['uri_field'] }}</th>
+                {% endif %}
+                  <th>id</th>
+                  {% if data['title_field'] %}
+                    <th>{{ data['title_field'] }}</th>
+                  {% endif %}
+                  {% for k, v in data['features'][0]['properties'].items() %}
+                    {# start with id & title then take first 5 columns for table #}
+                    {% if loop.index < 5 and k not in [data['id_field'], data['title_field'], data['uri_field'], 'extent'] %}
+                    <th>{{ k }}</th>
+                    {% endif %}
+                  {% endfor %}
+              </tr>
             </thead>
             <tbody>
               <tr v-for="(item, index) in items">
                 <td v-for="(th, index) in tableFields" v-html="linkToRow(item, th.key, itemsPath)">
                 </td>
               </tr>
+              {% for ft in data['features'] %}
+              <tr v-if="noJs">
+                {% if data.get('uri_field') %}
+                <td data-label="{{ data.get('uri_field') }}"><a href="{{ ft['properties'].get(data['uri_field'])}}" title="{{ ft['properties'][data['uri_field']] }}">{{ft['properties'][data.get('uri_field')]}}</a></td>
+                {% endif %}
+                <td data-label="id"><a href="{{ data['items_path']}}/{{ ft.id }}" title="{{ ft.id }}">{{ ft.id | string | truncate( 12 )  }}</a></td>
+                {% if data['title_field'] %}
+                  <td data-label="name"><a href="{{ data['items_path']}}/{{ ft['id'] }}" title="{{ ft['properties'][data['title_field']] }}">{{ ft['properties'][data['title_field']] | string | truncate( 35 ) }}</a></td>
+                {% endif %}
+                {% for k, v in ft['properties'].items() %}
+                  {% if loop.index < 5 and k not in [data['id_field'], data['title_field'], data['uri_field'], 'extent'] %}
+                  <td data-label="{{ k }}">{{ v | string | truncate( 35 ) }}</td>
+                  {% endif %}
+                {% endfor %}
+              </tr>
+            {% endfor %}
             </tbody>
           </table>
         </div>
@@ -116,6 +147,8 @@
       const app = createApp({
         delimiters: ['[%', '%]'],
         setup() {
+          const noJs = ref(false) // progressive enhancement
+
           // Items handling
           const { items, itemsJson, itemProps, getItems, itemsTotal, itemsLoading,
             currentPage, maxPages, prevPage, nextPage, limit, showingLimitText } = useItems()

--- a/theme/templates/stac/catalog.html
+++ b/theme/templates/stac/catalog.html
@@ -25,12 +25,15 @@
           <tr>
             <th v-for="(th, index) in tableFields"
               :class="['sortable']"
-              @click="sortDir(th.key)">[% th.text %]
+              @click="sortDir(th.key)">
+              <span v-text="th.text">Name</span>
               <span
                 v-show="currentSort === th.key"
                 :class="sortIconClass"
                 class="glyphicon"></span>
             </th>
+            <th v-if="noJs">Last modified</th>
+            <th v-if="noJs">Size</th>
           </tr>
         </thead>
         <tbody>
@@ -38,12 +41,32 @@
             <td v-for="(th, index) in tableFields">
               <a v-if="th.key === 'name'" :title="truncateStripTags(link.name)"
                 :href="link.href">
-                <span>[% link[th.key] %]</span></a>
+                <span v-text="link[th.key]"></span></a>
               <template v-else>
-                <span>[% link[th.key] %]</span>
+                <span v-text="link[th.key]"></span>
               </template>
             </td>
           </tr>
+
+          {% for link in data['links'] %}
+          {% if link['rel'] in ['child', 'item'] %}
+          <tr v-if="noJs">
+            <td data-label="name">
+              {% if link['title'] %}
+              <a title="{{ link['href'] }}" href="{{ link['href'] }}"><span>{{ link['title'] | get_path_basename }}</span></a>
+              {% else %}
+              <a title="{{ link['href'] }}" href="{{ link['href'] }}"><span>{{ link['href'] | get_path_basename }}</span></a>
+              {% endif %}
+            </td>
+            <td data-label="created">{{ link['created'] }}</td>
+            {% if link['file:size'] %}
+            <td data-label="size">{{ link['file:size'] | human_size }}</td>
+            {% else %}
+            <td data-label="size">-</td>
+            {% endif %}
+          </tr>
+          {% endif %}
+          {% endfor %}
         </tbody>
       </table>
     </div>
@@ -61,6 +84,8 @@
     const app = createApp({
       delimiters: ['[%', '%]'],
       setup() {
+        const noJs = ref(false) // progressive enhancement
+        
         const { childLinks, itemLinks } = useCatalog()
 
         // table columns


### PR DESCRIPTION
Re-enable the original Jinja rendering of HTML tables for collections list, collection items and STAC listing to allow for no JavaScript viewing.
- Turns off original HTML table renderings when JS is on.