### PR TITLE
Permalinks for OAFeat searches

### DIFF
--- a/theme/static/js/composables/useItems.js
+++ b/theme/static/js/composables/useItems.js
@@ -1,4 +1,4 @@
-import { ref, computed, onMounted, watch } from 'https://cdnjs.cloudflare.com/ajax/libs/vue/3.0.7/vue.esm-browser.prod.js'
+import { ref, computed } from 'https://cdnjs.cloudflare.com/ajax/libs/vue/3.0.7/vue.esm-browser.prod.js'
 
 export default function useItems() {
   // Items results

--- a/theme/static/js/composables/useItems.js
+++ b/theme/static/js/composables/useItems.js
@@ -37,7 +37,7 @@ export default function useItems() {
     let showText = `Showing ${parseInt(startindex.value) + 1} to ${upper} of ${itemsTotal.value}`
     return showText
   })
-  const startindex = computed(() => {
+  const calcStartIndex = () => {
     if (currentPage.value === 1) {
       return 0
     } else {
@@ -49,6 +49,9 @@ export default function useItems() {
         return index
       }
     }
+  }
+  const startindex = computed(() => {
+    return calcStartIndex()
   })
   const maxPages = computed(() => {
     return Math.ceil(itemsTotal.value / limit.value)
@@ -124,24 +127,11 @@ export default function useItems() {
       queryCols.value[key] = ''
     }
   }
-  
-  // initialize with base data retrieval
-  onMounted(() => {
-    getItems()
-      .then(() => { // success
-        if (Object.entries(queryCols.value).length === 0) {
-          // initialize queryCols once
-          itemProps.value.forEach((key) => {
-            queryCols.value[key] = ''
-          })
-        }
-      })
-  })
 
   return {
     itemsJson, itemsTotal, items, itemProps, limit,
     getItems, showingLimitText, itemsLoading,
-    nextPage, prevPage, currentPage, maxPages,
+    nextPage, prevPage, currentPage, maxPages, calcStartIndex,
     queryCols, clearQueryCols, queryColsIsEmpty
   }
 }

--- a/theme/static/js/composables/useTableFilter.js
+++ b/theme/static/js/composables/useTableFilter.js
@@ -117,16 +117,30 @@ export default function useTableFilter(rows, keyColumns, defaultSortCol) {
   // const maxPages = computed(() => {
   //   return Math.ceil(filteredNumEntries / pageSize)
   // })
-  const showingFilterText = computed(() => {
-    let showText = `Showing ${startEntryOfPage.value} to ${lastEntryOfPage.value} of ${filteredNumEntries.value}`
+  const filteredFromText = computed(() => {
     if (filteredNumEntries.value < totalSize.value) {
       if (totalSize.value === 1) {
         // singular case
-        showText += `(filtered from {totalSize} total entry)`
+        return `filtered from ${totalSize.value} total entry`
       } else { // > 1
         // plural case
-        showText += `(filtered from ${totalSize.value} total entries)`
+        return `filtered from ${totalSize.value} total entries`
       }
+    } else {
+      return ''
+    }
+  })
+  const showingFilteredFromText = computed(() => {
+    if (filteredFromText.value !== '') {
+      return filteredNumEntries.value + ' ' + filteredFromText.value
+    } else {
+      return ''
+    }
+  })
+  const showingFilterText = computed(() => {
+    let showText = `Showing ${startEntryOfPage.value} to ${lastEntryOfPage.value} of ${filteredNumEntries.value}`
+    if (filteredFromText.value !== '') {
+      showText += ` (${filteredFromText.value})`
     }
     return showText
   })
@@ -165,7 +179,7 @@ export default function useTableFilter(rows, keyColumns, defaultSortCol) {
   return {
     filteredRows, searchText, searchTextLowered,
     currentSortDir, currentSort, sortDir, sortIconClass, 
-    pageSize, currentPage, paginatedRows, prevPage, nextPage, showingFilterText,
+    pageSize, currentPage, paginatedRows, prevPage, nextPage, showingFilterText, showingFilteredFromText,
     truncateStripTags, stripTags, truncate, linkToRow
   }
 }

--- a/theme/templates/collections/items/index.html
+++ b/theme/templates/collections/items/index.html
@@ -305,9 +305,6 @@
                 currentSort.value = sortby.substr(1)
               } else if (sortby[0] === '+') { // explicit ascending sort
                 currentSort.value = sortby.substr(1)
-                // remove '+' to simplify URL; ascending sort is implicit
-                queryParams.set('sortby', currentSort.value )
-                history.replaceState(null, null, "?"+queryParams.toString())
               } else {
                 currentSort.value = sortby
               }

--- a/theme/templates/collections/items/index.html
+++ b/theme/templates/collections/items/index.html
@@ -244,6 +244,7 @@
           const queryParams = new URLSearchParams(window.location.search)
           const nonQueryColumns = ['sortby', 'startindex', 'limit', 'f']
           const params = Object.fromEntries(queryParams.entries())
+          let historyState = 1
           const updateQueryParams = function () {
             queryParams.set('limit', limit.value)
             queryParams.set('startindex', calcStartIndex())
@@ -266,9 +267,9 @@
                 }
               }
             }
-            history.pushState(null, null, "?"+queryParams.toString())
+            history.pushState(params, null, "?"+queryParams.toString())
           }
-          onBeforeMount(() => { // on load permalink
+          const permalinkMount = function () {
             // limit
             if (queryParams.has('limit')) {
               limit.value = parseInt(params.limit)
@@ -308,12 +309,23 @@
                 queryCols.value[key] = params[key] + '' // stringify
               }
             }
+          }
+          onBeforeMount(() => { // on page load permalink
+            permalinkMount()
           })
 
           // initial httpRequest to populate table
           onMounted(() => {
             getItems(currentSort.value, currentSortDir.value)
           })
+
+          // history back handling
+          window.onpopstate = function (evt) {
+            history.pushState(null, null, location.href)
+            permalinkMount()
+            getItemsSorted()
+          }
+          
 
           return {
             tableFields, keyColumns, itemsTotal, itemsLoading,

--- a/theme/templates/collections/items/index.html
+++ b/theme/templates/collections/items/index.html
@@ -129,7 +129,8 @@
               </div>
             </div>
             <div class="col-xs-7 col-sm-6 text-right">
-              <div v-text="showingLimitText"></div>
+              <span v-text="showingLimitText"></span>
+              <span v-show="showingFilteredFromText !== ''" v-text="' (' + showingFilteredFromText + ')'"></span>
             </div>
           </div>
           <div class="alert alert-warning padding-tb-5 mrgn-bttm-0 mrgn-tp-sm">
@@ -195,7 +196,7 @@
 
           // Table filtering
           const defaultSortCol = 'id'
-          const { searchText, searchTextLowered, truncate,
+          const { searchText, searchTextLowered, truncate, showingFilteredFromText,
             currentSort, currentSortDir, sortDir, sortIconClass, filteredRows, linkToRow } = useTableFilter(items, keyColumns, defaultSortCol)
           const changeSortDir = function (col) {
             sortDir(col)
@@ -241,9 +242,9 @@
           useMap('items-map', itemsJson, itemsPath, tileLayerUrl, tileLayerAttr)
 
           // Permalink handling
-          const queryParams = new URLSearchParams(window.location.search)
+          let queryParams = new URLSearchParams(window.location.search)
           const nonQueryColumns = ['sortby', 'startindex', 'limit', 'f']
-          const params = Object.fromEntries(queryParams.entries())
+          let params = Object.fromEntries(queryParams.entries())
           let historyState = 1
           const updateQueryParams = function () {
             queryParams.set('limit', limit.value)
@@ -269,7 +270,11 @@
             }
             history.pushState(params, null, "?"+queryParams.toString())
           }
-          const permalinkMount = function () {
+          const permalinkMount = function () { // reads the URL query params and applies the component
+            queryParams = new URLSearchParams(window.location.search)
+            params = Object.fromEntries(queryParams.entries())
+            console.log(params)
+
             // limit
             if (queryParams.has('limit')) {
               limit.value = parseInt(params.limit)
@@ -294,10 +299,15 @@
 
             // sort
             if (queryParams.has('sortby')) {
-              const sortby = params.sortby + '' // string
+              const sortby = params.sortby + '' // stringify
               if (sortby[0] === '-') { // descending sort
                 currentSortDir.value = 'desc'
                 currentSort.value = sortby.substr(1)
+              } else if (sortby[0] === '+') { // explicit ascending sort
+                currentSort.value = sortby.substr(1)
+                // remove '+' to simplify URL; ascending sort is implicit
+                queryParams.set('sortby', currentSort.value )
+                history.replaceState(null, null, "?"+queryParams.toString())
               } else {
                 currentSort.value = sortby
               }
@@ -310,7 +320,7 @@
               }
             }
           }
-          onBeforeMount(() => { // on page load permalink
+          onBeforeMount(() => { // on page load permalink handling
             permalinkMount()
           })
 
@@ -325,14 +335,13 @@
             permalinkMount()
             getItemsSorted()
           }
-          
 
           return {
             tableFields, keyColumns, itemsTotal, itemsLoading,
             items: filteredRows, // don't care for unfiltered
             searchText, searchTextLowered, truncate,
             sortIconClass, changeSortDir, currentSort, currentSortDir,
-            limit, limitOptions, showingLimitText, currentPage, maxPages, limitChange,
+            limit, limitOptions, showingLimitText, showingFilteredFromText, currentPage, maxPages, limitChange,
             itemsPath, linkToRow,
             queryCols, clearSearch, queryColsIsEmpty, applyKeywordSearch, prevPageItems, nextPageItems
           }

--- a/theme/templates/collections/items/index.html
+++ b/theme/templates/collections/items/index.html
@@ -51,7 +51,7 @@
               <button 
                 title="Apply column keyword search queries to the entire collection" 
                 class="btn btn-primary" 
-                @click="getItemsSorted()"
+                @click="applyKeywordSearch()"
                 :disabled="queryColsIsEmpty">
                 <span class="glyphicon glyphicon-search"></span> Search by keywords</button>
             </div>
@@ -79,7 +79,7 @@
                       :id="'search-'+th.key"
                       placeholder="Keyword"
                       v-model="queryCols[th.key]"
-                      @keyup.enter="getItemsSorted()" />
+                      @keyup.enter="applyKeywordSearch()" />
                   </div>
                 </th>
               </tr>
@@ -105,7 +105,7 @@
                   {% endif %}
                 {% endfor %}
               </tr>
-            {% endfor %}
+              {% endfor %}
             <!-- END of noJS -->
             </tbody>
           </table>
@@ -209,9 +209,13 @@
             searchText.value = ''
             getItemsSorted()
           }
+          const applyKeywordSearch = function () {
+            currentPage.value = 1 // Auto set to page 1 for keyword search
+            getItemsSorted()
+          }
           const getItemsSorted = function() {
             updateQueryParams()
-            getItems(currentSort.value, currentSortDir.value)
+            return getItems(currentSort.value, currentSortDir.value)
           }
           const prevPageItems = function() {
             prevPage()
@@ -238,6 +242,7 @@
 
           // Permalink handling
           const queryParams = new URLSearchParams(window.location.search)
+          const nonQueryColumns = ['sortby', 'startindex', 'limit', 'f']
           const params = Object.fromEntries(queryParams.entries())
           const updateQueryParams = function () {
             queryParams.set('limit', limit.value)
@@ -251,6 +256,16 @@
             } else {
               queryParams.delete('sortby')
             }
+            for (const key of itemProps.value) {
+              queryParams.delete(key)
+            }
+            if (!queryColsIsEmpty.value) {
+              for (const [key, val] of Object.entries(queryCols.value)) {
+                if (val !== '') {
+                  queryParams.set(key, val)
+                }
+              }
+            }
             history.pushState(null, null, "?"+queryParams.toString())
           }
           onBeforeMount(() => { // on load permalink
@@ -258,6 +273,16 @@
             if (queryParams.has('limit')) {
               limit.value = parseInt(params.limit)
             }
+            onMounted(() => { // Add limit select option if new
+              // limit select option
+              if (queryParams.has('limit')) {
+                const limitValue = parseInt(params.limit)
+                if (!limitOptions.includes(limitValue)) {
+                  limitOptions.push(limitValue)
+                  limitOptions.sort((a,b) => a-b) // number sort
+                }
+              }
+            })
 
             // pagination - startindex
             if (queryParams.has('startindex')) {
@@ -276,29 +301,18 @@
                 currentSort.value = sortby
               }
             }
-          })
-          onMounted(() => { // Add limit select option if new
-            // limit select option
-            if (queryParams.has('limit')) {
-              const limitValue = parseInt(params.limit)
-              if (!limitOptions.includes(limitValue)) {
-                limitOptions.push(limitValue)
-                limitOptions.sort((a,b) => a-b) // number sort
+
+            // other columns / keyword searches
+            for (const key of queryParams.keys()) {
+              if (!nonQueryColumns.includes(key)) {
+                queryCols.value[key] = params[key] + '' // stringify
               }
             }
           })
 
-          // initialize with base data retrieval
+          // initial httpRequest to populate table
           onMounted(() => {
             getItems(currentSort.value, currentSortDir.value)
-              .then(() => { // success
-                if (Object.entries(queryCols.value).length === 0) {
-                  // initialize queryCols once
-                  itemProps.value.forEach((key) => {
-                    queryCols.value[key] = ''
-                  })
-                }
-              })
           })
 
           return {
@@ -308,7 +322,7 @@
             sortIconClass, changeSortDir, currentSort, currentSortDir,
             limit, limitOptions, showingLimitText, currentPage, maxPages, limitChange,
             itemsPath, linkToRow,
-            queryCols, clearSearch, queryColsIsEmpty, getItemsSorted, prevPageItems, nextPageItems
+            queryCols, clearSearch, queryColsIsEmpty, applyKeywordSearch, prevPageItems, nextPageItems
           }
         }
       })

--- a/theme/templates/collections/items/index.html
+++ b/theme/templates/collections/items/index.html
@@ -273,7 +273,6 @@
           const permalinkMount = function () { // reads the URL query params and applies the component
             queryParams = new URLSearchParams(window.location.search)
             params = Object.fromEntries(queryParams.entries())
-            console.log(params)
 
             // limit
             if (queryParams.has('limit')) {

--- a/theme/templates/collections/items/index.html
+++ b/theme/templates/collections/items/index.html
@@ -64,7 +64,7 @@
               <tr>
                 <th v-for="(th, index) in tableFields"
                   :class="th.colClass">
-                  <div class="sortable ellipsis" @click="sortDir(th.key)" :title="th.text">
+                  <div class="sortable ellipsis" @click="changeSortDir(th.key)" :title="th.text">
                     <span v-text="truncate(th.text, 15)"></span>
                     <span
                       v-show="currentSort === th.key"
@@ -89,6 +89,7 @@
                 <td v-for="(th, index) in tableFields" v-html="linkToRow(item, th.key, itemsPath)">
                 </td>
               </tr>
+              <!-- START of noJs progressive enhancement -->
               {% for ft in data['features'] %}
               <tr v-if="noJs">
                 {% if data.get('uri_field') %}
@@ -105,6 +106,7 @@
                 {% endfor %}
               </tr>
             {% endfor %}
+            <!-- END of noJS -->
             </tbody>
           </table>
         </div>
@@ -116,14 +118,12 @@
                 <div class="form-group inline-block">
                   <label>Limit: </label>
                   <select
+                    id="select-limit"
                     class="input-sm form-control inline-block"
                     v-model="limit"
                     :disabled="itemsLoading"
                     @change="limitChange()">
-                      <option value="10">10</option>
-                      <option value="100">100</option>
-                      <option value="1000">1000</option>
-                      <option value="2000">2000</option>
+                      <option v-for="value of limitOptions" :value="value" v-text="value"></option>
                   </select>
                 </div>
               </div>
@@ -162,9 +162,8 @@
       import useItems from '{{ config['server']['url'] }}/static/js/composables/useItems.js?v={{ version }}'
       import useTableFilter from '{{ config['server']['url'] }}/static/js/composables/useTableFilter.js?v={{ version }}'
       import useMap from '{{ config['server']['url'] }}/static/js/composables/useMap.js?v={{ version }}'
-      import { createApp, ref, computed, watch, onMounted } from 'https://cdnjs.cloudflare.com/ajax/libs/vue/3.0.7/vue.esm-browser.prod.js'
+      import { createApp, ref, computed, onBeforeMount, onMounted } from 'https://cdnjs.cloudflare.com/ajax/libs/vue/3.0.7/vue.esm-browser.prod.js'
 
-      
       const app = createApp({
         delimiters: ['[%', '%]'],
         setup() {
@@ -172,7 +171,7 @@
 
           // Items handling
           const { items, itemsJson, itemProps, getItems, itemsTotal, itemsLoading,
-            currentPage, maxPages, prevPage, nextPage, limit, showingLimitText,
+            currentPage, maxPages, prevPage, nextPage, limit, showingLimitText, calcStartIndex,
             queryCols, clearQueryCols, queryColsIsEmpty } = useItems()
           
           // Table columns
@@ -195,8 +194,14 @@
           })
 
           // Table filtering
+          const defaultSortCol = 'id'
           const { searchText, searchTextLowered, truncate,
-            currentSort, currentSortDir, sortDir, sortIconClass, filteredRows, linkToRow } = useTableFilter(items, keyColumns, 'id')
+            currentSort, currentSortDir, sortDir, sortIconClass, filteredRows, linkToRow } = useTableFilter(items, keyColumns, defaultSortCol)
+          const changeSortDir = function (col) {
+            sortDir(col)
+            getItemsSorted()
+            updateQueryParams()
+          }
           
           // Collection searching
           const clearSearch = function() {
@@ -205,6 +210,7 @@
             getItemsSorted()
           }
           const getItemsSorted = function() {
+            updateQueryParams()
             getItems(currentSort.value, currentSortDir.value)
           }
           const prevPageItems = function() {
@@ -215,6 +221,7 @@
             nextPage()
             getItemsSorted()
           }
+          const limitOptions = [10, 100, 1000, 2000]
           const limitChange = function () {
             // Cannot have current page > max pages on limit changes
             if (currentPage.value > maxPages.value) {
@@ -229,12 +236,77 @@
           const tileLayerAttr = '{{ config['server']['map']['attribution'] }}'
           useMap('items-map', itemsJson, itemsPath, tileLayerUrl, tileLayerAttr)
 
+          // Permalink handling
+          const queryParams = new URLSearchParams(window.location.search)
+          const params = Object.fromEntries(queryParams.entries())
+          const updateQueryParams = function () {
+            queryParams.set('limit', limit.value)
+            queryParams.set('startindex', calcStartIndex())
+            if (currentSort.value !== defaultSortCol) { // don't apply sortby for default "id" column
+              let sortby = currentSort.value
+              if (currentSortDir.value === 'desc') {
+                sortby = '-' + sortby
+              }
+              queryParams.set('sortby', sortby)
+            } else {
+              queryParams.delete('sortby')
+            }
+            history.pushState(null, null, "?"+queryParams.toString())
+          }
+          onBeforeMount(() => { // on load permalink
+            // limit
+            if (queryParams.has('limit')) {
+              limit.value = parseInt(params.limit)
+            }
+
+            // pagination - startindex
+            if (queryParams.has('startindex')) {
+              // calculate currentPage with limit
+              const startindex = parseInt(params.startindex)
+              currentPage.value = Math.floor((startindex/limit.value) + 1)
+            }
+
+            // sort
+            if (queryParams.has('sortby')) {
+              const sortby = params.sortby + '' // string
+              if (sortby[0] === '-') { // descending sort
+                currentSortDir.value = 'desc'
+                currentSort.value = sortby.substr(1)
+              } else {
+                currentSort.value = sortby
+              }
+            }
+          })
+          onMounted(() => { // Add limit select option if new
+            // limit select option
+            if (queryParams.has('limit')) {
+              const limitValue = parseInt(params.limit)
+              if (!limitOptions.includes(limitValue)) {
+                limitOptions.push(limitValue)
+                limitOptions.sort((a,b) => a-b) // number sort
+              }
+            }
+          })
+
+          // initialize with base data retrieval
+          onMounted(() => {
+            getItems(currentSort.value, currentSortDir.value)
+              .then(() => { // success
+                if (Object.entries(queryCols.value).length === 0) {
+                  // initialize queryCols once
+                  itemProps.value.forEach((key) => {
+                    queryCols.value[key] = ''
+                  })
+                }
+              })
+          })
+
           return {
             tableFields, keyColumns, itemsTotal, itemsLoading,
             items: filteredRows, // don't care for unfiltered
             searchText, searchTextLowered, truncate,
-            sortIconClass, sortDir, currentSort, currentSortDir,
-            limit, showingLimitText, currentPage, maxPages, limitChange,
+            sortIconClass, changeSortDir, currentSort, currentSortDir,
+            limit, limitOptions, showingLimitText, currentPage, maxPages, limitChange,
             itemsPath, linkToRow,
             queryCols, clearSearch, queryColsIsEmpty, getItemsSorted, prevPageItems, nextPageItems
           }

--- a/theme/templates/collections/items/index.html
+++ b/theme/templates/collections/items/index.html
@@ -201,7 +201,6 @@
           const changeSortDir = function (col) {
             sortDir(col)
             getItemsSorted()
-            updateQueryParams()
           }
           
           // Collection searching
@@ -214,8 +213,8 @@
             currentPage.value = 1 // Auto set to page 1 for keyword search
             getItemsSorted()
           }
-          const getItemsSorted = function() {
-            updateQueryParams()
+          const getItemsSorted = function(lastHistoryState = null) {
+            updateQueryParams(lastHistoryState)
             return getItems(currentSort.value, currentSortDir.value)
           }
           const prevPageItems = function() {
@@ -245,8 +244,10 @@
           let queryParams = new URLSearchParams(window.location.search)
           const nonQueryColumns = ['sortby', 'startindex', 'limit', 'f']
           let params = Object.fromEntries(queryParams.entries())
-          let historyState = 1
-          const updateQueryParams = function () {
+          let historyState = 1 // internal state handling for back/forward
+          const updateQueryParams = function (lastHistoryState = null) {
+            queryParams = new URLSearchParams(window.location.search)
+            params = Object.fromEntries(queryParams.entries())
             queryParams.set('limit', limit.value)
             queryParams.set('startindex', calcStartIndex())
             if (currentSort.value !== defaultSortCol) { // don't apply sortby for default "id" column
@@ -268,9 +269,19 @@
                 }
               }
             }
-            history.pushState(params, null, "?"+queryParams.toString())
+
+            // browser back/forward history handling
+            if (lastHistoryState !== null) {
+                historyState = lastHistoryState
+            }
+
+            // no browser back/forward was pressed
+            if (history.state !== lastHistoryState || history.state === null) {
+              history.pushState(historyState, null, '?' + queryParams.toString())
+              historyState++
+            }
           }
-          const permalinkMount = function () { // reads the URL query params and applies the component
+          const permalinkMount = function () { // reads the URL query params and applies to vm
             queryParams = new URLSearchParams(window.location.search)
             params = Object.fromEntries(queryParams.entries())
 
@@ -327,9 +338,9 @@
 
           // history back handling
           window.onpopstate = function (evt) {
-            history.pushState(null, null, location.href)
+            evt.preventDefault()
             permalinkMount()
-            getItemsSorted()
+            getItemsSorted(evt.state)
           }
 
           return {


### PR DESCRIPTION
Allow permalinks with
- `sortby=`
- `limit=`
- `<PROPERTY_NAME>=`
- `startindex=`

Browser history back and forward buttons enabled to work with permalink changes.