### PR TITLE
Fix AQHI cleanup bug

### DIFF
--- a/debian/msc-pygeoapi.cron.d
+++ b/debian/msc-pygeoapi.cron.d
@@ -37,7 +37,7 @@
 0 5 * * * geoadm msc-pygeoapi data swob_realtime clean_indexes --days 30 --yes
 
 # every day at 0600h, clean aqhi realtime data older than 30 days
-0 6 * * * geoadm msc-pygeoapi data aqhi_realtime clean_indexes --days 3 --yes
+0 6 * * * geoadm msc-pygeoapi data aqhi_realtime clean_indexes --dataset all --days 3 --yes
 
 # every day at 0300h, clean out empty MetPX directories
 0 3 * * * geoadm /usr/bin/find $MSC_PYGEOAPI_CACHEDIR -type d -empty -delete > /dev/null 2>&1

--- a/msc_pygeoapi/loader/aqhi_realtime.py
+++ b/msc_pygeoapi/loader/aqhi_realtime.py
@@ -340,7 +340,7 @@ def clean_indexes(ctx, days, dataset, es, username, password, ignore_certs):
         indexes_to_delete = check_es_indexes_to_delete(indexes, days)
         if indexes_to_delete:
             click.echo('Deleting indexes {}'.format(indexes_to_delete))
-            conn.delete(','.join(indexes))
+            conn.delete(','.join(indexes_to_delete))
 
     click.echo('Done')
 


### PR DESCRIPTION
I fixed the AQHI cleanup bug where the cleanup cron command would not work (missing `--dataset all`). 

I also fixed the problem where the cleanup would delete all indexes of AQHI instead of the ones that are older than 3 days (with `--days`).