### PR TITLE
Removal of trans tags causing jinja2 template errors

### DIFF
--- a/theme/templates/collections/items/index.html
+++ b/theme/templates/collections/items/index.html
@@ -197,14 +197,21 @@
                 colClass: ''
               })
               itemProps.value.forEach((prop) => {
+                // avoid duplicate id for none case
+                if ((prop.toLowerCase() === 'id') && (ID_FIELD.toLowerCase() === 'none')) {
+                  return // skip
+                } 
+
                 // avoid duplicate columns if root id and ID_FIELD are the same
-                if ((prop.toLowerCase() !== ID_FIELD.toLowerCase()) && (prop.toLowerCase() !== 'id')) {
-                  fields.push({
-                    key: prop,
-                    text: prop,
-                    colClass: ''
-                  })
+                if (prop.toLowerCase() === ID_FIELD.toLowerCase()) {
+                  return // skip
                 }
+
+                fields.push({
+                  key: prop,
+                  text: prop,
+                  colClass: ''
+                })
               })
             }
             return fields

--- a/theme/templates/collections/items/item.html
+++ b/theme/templates/collections/items/item.html
@@ -20,15 +20,15 @@
       {{ val | urlize() }}
     {% endif %}
 {%- endmacro %}
-{% block title %}{{ super() }} {{ data['title'] }} - {{ data['id'] }}{% endblock %}
+{% block title %}{{ ptitle }} - {{ super() }}{% endblock %}
 {% block crumbs %}{{ super() }}
 <li><a href="../../../collections">Collections</a></li>
 {% for link in data['links'] %}
   {% if link.rel == 'collection' %}
-  <li><a href="{{ link['href'] }}">{{ link['title'] }}</a></li>
+  <li><a href="{{ link['href'] }}">{{ link['title'] | truncate( 25 ) }}</a></li>
   {% endif %}
 {% endfor %}
-<li><a href="../items">{% trans %}Items{% endtrans %}</a></li>
+<li><a href="../items">Items</a></li>
 <li><a href="./{{ data['id'] }}">{{ ptitle | truncate( 25 ) }}</a></li>
 {% endblock %}
 {% block extrahead %}
@@ -57,9 +57,9 @@
                 <div class="col-sm-12">
                   {% for link in data['links'] %}
                   {% if link['rel'] == 'prev' %}
-                  <a role="button" href="./{{ data['prev'] }}">{% trans %}Prev{% endtrans %}</a>
+                  <a role="button" href="./{{ data['prev'] }}">Prev</a>
                   {% elif link['rel'] == 'next' %}
-                  <a role="button" href="./{{ data['next'] }}">{% trans %}Next{% endtrans %}</a>
+                  <a role="button" href="./{{ data['next'] }}">Next</a>
                   {% endif %}
                   {% endfor %}
                 </div>
@@ -72,8 +72,8 @@
             <table class="table table-striped">
               <thead>
               <tr>
-                <th>{% trans %}Property{% endtrans %}</th>
-                <th>{% trans %}Value{% endtrans %}</th>
+                <th>Property</th>
+                <th>Value</th>
               </tr>
             </thead>
             <tbody>

--- a/theme/templates/collections/items/item.html
+++ b/theme/templates/collections/items/item.html
@@ -20,7 +20,7 @@
       {{ val | urlize() }}
     {% endif %}
 {%- endmacro %}
-{% block title %}{{ ptitle }} - {{ super() }}{% endblock %}
+{% block title %}{{ super() }} {{ ptitle }}{% endblock %}
 {% block crumbs %}{{ super() }}
 <li><a href="../../../collections">Collections</a></li>
 {% for link in data['links'] %}


### PR DESCRIPTION
- Match items.html jinja template with https://github.com/geopython/pygeoapi/blob/0.10.1/pygeoapi/templates/collections/items/item.html; removal of trans tags
- Fix to page title display order in head of `items.html`
- Minor: reorganzied if statements for duplicate ID field handling