### PR TITLE
updated bulletins retention time to 140 days

### DIFF
--- a/debian/msc-pygeoapi.cron.d
+++ b/debian/msc-pygeoapi.cron.d
@@ -28,7 +28,7 @@
 # =================================================================
 
 # every day at 0300h, clean bulletin records from ES
-0 3 * * * geoadm msc-pygeoapi data bulletins_realtime clean_indexes --days 170 --yes
+0 3 * * * geoadm msc-pygeoapi data bulletins_realtime clean_indexes --days 140 --yes
 
 # every day at 0400h, clean hydrometric realtime data older than 30 days
 0 4 * * * geoadm msc-pygeoapi data hydrometric_realtime clean_indexes --days 30 --yes

--- a/deploy/default/msc-pygeoapi-config.yml
+++ b/deploy/default/msc-pygeoapi-config.yml
@@ -1162,7 +1162,7 @@ resources:
     bulletins-realtime:
         type: collection
         title: Real-time meteorological bulletins
-        description: Real-time meteorological bulletins (last 170 days)
+        description: Real-time meteorological bulletins (last 140 days)
         keywords: [alphanumerical, binary, bulletins]
         crs:
             - CRS84

--- a/deploy/default/msc-pygeoapi-openapi.yml
+++ b/deploy/default/msc-pygeoapi-openapi.yml
@@ -1878,7 +1878,7 @@ paths:
       - aqhi-observations-realtime
   /collections/bulletins-realtime:
     get:
-      description: Real-time meteorological bulletins (last 170 days)
+      description: Real-time meteorological bulletins (last 140 days)
       operationId: describeBulletins-realtimeCollection
       parameters:
       - $ref: '#/components/parameters/f'
@@ -1896,7 +1896,7 @@ paths:
       - bulletins-realtime
   /collections/bulletins-realtime/items:
     get:
-      description: Real-time meteorological bulletins (last 170 days)
+      description: Real-time meteorological bulletins (last 140 days)
       operationId: getBulletins-realtimeFeatures
       parameters:
       - *id001
@@ -1980,7 +1980,7 @@ paths:
       - bulletins-realtime
   /collections/bulletins-realtime/items/{featureId}:
     get:
-      description: Real-time meteorological bulletins (last 170 days)
+      description: Real-time meteorological bulletins (last 140 days)
       operationId: getBulletins-realtimeFeature
       parameters:
       - $ref: https://api.wxod-dev.cmc.ec.gc.ca/schemas/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml#/components/parameters/featureId
@@ -1999,7 +1999,7 @@ paths:
       - bulletins-realtime
   /collections/bulletins-realtime/queryables:
     get:
-      description: Real-time meteorological bulletins (last 170 days)
+      description: Real-time meteorological bulletins (last 140 days)
       operationId: getBulletins-realtimeQueryables
       parameters:
       - *id001
@@ -11845,7 +11845,7 @@ tags:
     The AQHI is calculated from data observed in real time, without being verified
     (quality control).
   name: aqhi-observations-realtime
-- description: Real-time meteorological bulletins (last 170 days)
+- description: Real-time meteorological bulletins (last 140 days)
   name: bulletins-realtime
 - description: Raster Drill process
   name: raster-drill

--- a/msc_pygeoapi/loader/bulletins_realtime.py
+++ b/msc_pygeoapi/loader/bulletins_realtime.py
@@ -43,7 +43,7 @@ from msc_pygeoapi.util import (
 LOGGER = logging.getLogger(__name__)
 
 # cleanup settings
-DAYS_TO_KEEP = 170
+DAYS_TO_KEEP = 140
 
 # index settings
 INDEX_BASENAME = 'bulletins.'


### PR DESCRIPTION
This is for the 2.16 release so it should be back ported.

updated bulletins retention time to 140 days because we see that on DD retention time is 150 days. Note that the DD documentation says it should be kept for 6 months.