### PR TITLE
Add CSV format link in /items page and Output Formats in /collection page

### DIFF
--- a/theme/templates/_base.html
+++ b/theme/templates/_base.html
@@ -82,6 +82,8 @@
                 </a>
               </li>
               {% endif %}
+              {% block extralang %}
+              {% endblock %}
             </ul>
           </section>
 

--- a/theme/templates/collections/collection.html
+++ b/theme/templates/collections/collection.html
@@ -63,7 +63,7 @@
       {% for link in data['links'] %}
         {% if link['rel'] == 'items' and link['type'] == 'application/geo+json' %}
           <li>GeoJSON</li>
-          <li>CSV</li>{# generally supported with GeoJSON #}
+          <li>CSV</li>{# generally supported with pygeoapi feature collections #}
         {% endif %}
       {% endfor %}
       </ul>

--- a/theme/templates/collections/collection.html
+++ b/theme/templates/collections/collection.html
@@ -57,7 +57,16 @@
       </ul>
         {% endif %}
       {% endfor %}
-      {% endif  %}
+      {% endif %}
+      <h3>Output Formats</h3>
+      <ul>
+      {% for link in data['links'] %}
+        {% if link['rel'] == 'items' and link['type'] == 'application/geo+json' %}
+          <li>GeoJSON</li>
+          <li>CSV</li>{# generally supported with GeoJSON #}
+        {% endif %}
+      {% endfor %}
+      </ul>
       <h3>Links</h3>
       <ul>
       {% for link in data['links'] %}

--- a/theme/templates/collections/items/index.html
+++ b/theme/templates/collections/items/index.html
@@ -1,5 +1,17 @@
 {% extends "_base.html" %}
 {% block title %}{{ super() }} {{ data['title'] }} {% endblock %}
+{% block extralang %}
+{% for link in data['links'] %}
+{% if link['rel'] == 'alternate' and link['type'] == 'application/geo+json' %}
+<li>
+  <a id="csv-format-url" href="{{ link['href']|replace('f=json', 'f=csv') }}">
+    <span class="hidden-xs">CSV</span>
+    <abbr title="JSON" class="visible-xs h3 mrgn-tp-sm mrgn-bttm-0 text-uppercase">CSV</abbr>
+  </a>
+</li>
+{% endif %}
+{% endfor %}
+{% endblock %}
 {% block crumbs %}{{ super() }}
 <li><a href="{{ data['collections_path'] }}">Collections</a></li>
 {% for link in data['links'] %}
@@ -278,6 +290,8 @@
             jsonLink.href = '?' + queryParams.toString() + '&f=json'
             let jsonLdLink = document.getElementById('jsonld-format-url')
             jsonLdLink.href = '?' + queryParams.toString() + '&f=jsonld'
+            let csvLink = document.getElementById('csv-format-url')
+            jsonLdLink.href = '?' + queryParams.toString() + '&f=csv'
           }
           // updates URL query params with current state
           const updateQueryParams = function(lastHistoryState = null) {

--- a/theme/templates/collections/items/index.html
+++ b/theme/templates/collections/items/index.html
@@ -6,7 +6,7 @@
 <li>
   <a id="csv-format-url" href="{{ link['href']|replace('f=json', 'f=csv') }}">
     <span class="hidden-xs">CSV</span>
-    <abbr title="JSON" class="visible-xs h3 mrgn-tp-sm mrgn-bttm-0 text-uppercase">CSV</abbr>
+    <abbr title="CSV" class="visible-xs h3 mrgn-tp-sm mrgn-bttm-0 text-uppercase">CSV</abbr>
   </a>
 </li>
 {% endif %}

--- a/theme/templates/collections/items/index.html
+++ b/theme/templates/collections/items/index.html
@@ -291,7 +291,7 @@
             let jsonLdLink = document.getElementById('jsonld-format-url')
             jsonLdLink.href = '?' + queryParams.toString() + '&f=jsonld'
             let csvLink = document.getElementById('csv-format-url')
-            jsonLdLink.href = '?' + queryParams.toString() + '&f=csv'
+            csvLink.href = '?' + queryParams.toString() + '&f=csv'
           }
           // updates URL query params with current state
           const updateQueryParams = function(lastHistoryState = null) {


### PR DESCRIPTION
Applies for any collection that supports `GeoJSON` format as metadata for CSV support is not yet available.