### PR TITLE
added support for indices in the config file

### DIFF
--- a/deploy/default/msc-pygeoapi-config.yml
+++ b/deploy/default/msc-pygeoapi-config.yml
@@ -1813,7 +1813,7 @@ resources:
             - climate
         extents:
             spatial:
-                bbox: [-150,41,-52,83.5]
+                bbox: [-141,41,-52,83.5]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         links:
             - type: text/html
@@ -1841,7 +1841,7 @@ resources:
             - climate
         extents:
             spatial:
-                bbox: [-150,41,-52,83.5]
+                bbox: [-141,41,-52,83.5]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         links:
             - type: text/html
@@ -1869,7 +1869,7 @@ resources:
             - climate
         extents:
             spatial:
-                bbox: [-150,41,-52,83.5]
+                bbox: [-141,41,-52,83.5]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         links:
             - type: text/html
@@ -1897,7 +1897,7 @@ resources:
             - climate
         extents:
             spatial:
-                bbox: [-150,41,-52,83.5]
+                bbox: [-141,41,-52,83.5]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         links:
             - type: text/html
@@ -1925,7 +1925,7 @@ resources:
             - climate
         extents:
             spatial:
-                bbox: [-150,41,-52,83.5]
+                bbox: [-141,41,-52,83.5]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         links:
             - type: text/html
@@ -1953,7 +1953,7 @@ resources:
             - climate
         extents:
             spatial:
-                bbox: [-150,41,-52,83.5]
+                bbox: [-141,41,-52,83.5]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         links:
             - type: text/html
@@ -1981,7 +1981,7 @@ resources:
             - climate
         extents:
             spatial:
-                bbox: [-150,41,-52,83.5]
+                bbox: [-141,41,-52,83.5]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         links:
             - type: text/html
@@ -2009,7 +2009,7 @@ resources:
             - climate
         extents:
             spatial:
-                bbox: [-150,41,-52,83.5]
+                bbox: [-141,41,-52,83.5]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         links:
             - type: text/html
@@ -2037,7 +2037,7 @@ resources:
             - climate
         extents:
             spatial:
-                bbox: [-150,41,-52,83.5]
+                bbox: [-141,41,-52,83.5]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         links:
             - type: text/html
@@ -2065,7 +2065,7 @@ resources:
             - climate
         extents:
             spatial:
-                bbox: [-150,41,-52,83.5]
+                bbox: [-141,41,-52,83.5]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         links:
             - type: text/html
@@ -2093,7 +2093,7 @@ resources:
             - climate
         extents:
             spatial:
-                bbox: [-150,41,-52,83.5]
+                bbox: [-141,41,-52,83.5]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         links:
             - type: text/html
@@ -2121,7 +2121,7 @@ resources:
             - climate
         extents:
             spatial:
-                bbox: [-150,41,-52,83.5]
+                bbox: [-141,41,-52,83.5]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         links:
             - type: text/html
@@ -2149,7 +2149,7 @@ resources:
             - climate
         extents:
             spatial:
-                bbox: [-150,41,-52,83.5]
+                bbox: [-141,41,-52,83.5]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         links:
             - type: text/html
@@ -2177,7 +2177,7 @@ resources:
             - climate
         extents:
             spatial:
-                bbox: [-150,41,-52,83.5]
+                bbox: [-141,41,-52,83.5]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         links:
             - type: text/html
@@ -2205,7 +2205,7 @@ resources:
             - climate
         extents:
             spatial:
-                bbox: [-150,41,-52,83.5]
+                bbox: [-141,41,-52,83.5]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         links:
             - type: text/html
@@ -2233,7 +2233,7 @@ resources:
             - climate
         extents:
             spatial:
-                bbox: [-150,41,-52,83.5]
+                bbox: [-141,41,-52,83.5]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         links:
             - type: text/html
@@ -2261,7 +2261,7 @@ resources:
             - climate
         extents:
             spatial:
-                bbox: [-150,41,-52,83.5]
+                bbox: [-141,41,-52,83.5]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         links:
             - type: text/html
@@ -2289,7 +2289,7 @@ resources:
             - climate
         extents:
             spatial:
-                bbox: [-150,41,-52,83.5]
+                bbox: [-141,41,-52,83.5]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
         links:
             - type: text/html
@@ -2301,6 +2301,62 @@ resources:
             - type: coverage
               name: msc_pygeoapi.provider.climate_xarray.ClimateProvider
               data: /data/geomet/feeds/dd.ops/climate/dcs/netcdf/historical/monthly_ens/absolute/DCS_hist_monthly_abs_latlon0.086x0.086_*_pctl50_P1M.nc
+              x_field: lon
+              y_field: lat
+              time_field: time
+              format:
+                  name: NetCDF
+                  mimetype: application/x-netcdf
+
+    Indices:projected:
+        type: collection
+        title: Projected indices
+        description: Projected indices
+        keywords:
+            - indices
+            - climate
+        extents:
+            spatial:
+                bbox: [-141,41,-52,83.5]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+        links:
+            - type: text/html
+              rel: canonical
+              title: information
+              href: https://open.canada.ca/data/en/dataset/
+              hreflang: en-CA
+        providers:
+            - type: coverage
+              name: msc_pygeoapi.provider.climate_xarray.ClimateProvider
+              data: /data/geomet/feeds/dd.ops/climate/indices/netcdf/scenarios/RCP2.6/INDICES_rcp2.6_2006-2100_latlon_0.086x0.086_*_pctl50.nc
+              x_field: lon
+              y_field: lat
+              time_field: time
+              format:
+                  name: NetCDF
+                  mimetype: application/x-netcdf
+
+    Indices:historical:
+        type: collection
+        title: Historical indices
+        description: Historical indices
+        keywords:
+            - indices
+            - climate
+        extents:
+            spatial:
+                bbox: [-141,41,-52,83.5]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+        links:
+            - type: text/html
+              rel: canonical
+              title: information
+              href: https://open.canada.ca/data/en/dataset/
+              hreflang: en-CA
+        providers:
+            - type: coverage
+              name: msc_pygeoapi.provider.climate_xarray.ClimateProvider
+              data: /data/geomet/feeds/dd.ops/climate/indices/netcdf/historical/INDICES_hist_1951-2005_latlon_0.086x0.086_*_pctl50.nc
               x_field: lon
               y_field: lat
               time_field: time


### PR DESCRIPTION
added support for indices in the config file and updated dcs bbox values.

The indices are using the general climate loader, just like CMIP5 and DCS.

2 indices collections are replacing 160 layers in geomet-climate.