### PR TITLE
 fix error for pcp range-subset in cangrd (2)

### DIFF
--- a/msc_pygeoapi/provider/cansips_rasterio.py
+++ b/msc_pygeoapi/provider/cansips_rasterio.py
@@ -272,7 +272,13 @@ class CanSIPSProvider(BaseProvider):
             raise ProviderQueryError(err)
 
         range_subset[0] = int(range_subset[0])
-        self.get_file_list(self.var_list[range_subset[0] - 1])
+        try:
+            var_list = self.var_list[range_subset[0] - 1]
+        except IndexError as err:
+            LOGGER.error(err)
+            raise ProviderQueryError(err)
+
+        self.get_file_list(var_list)
         self.member = subsets['member']
 
         args = {


### PR DESCRIPTION
fix error for pcp range-subset in cangrd

This error was because the pcp (precipitation) variable in cangrd does not have the same time extent as the temperature variables.

cc @kngai