### PR TITLE
Add support for custom filename

### DIFF
--- a/msc_pygeoapi/provider/cangrd_rasterio.py
+++ b/msc_pygeoapi/provider/cangrd_rasterio.py
@@ -3,7 +3,7 @@
 # Authors: Louis-Philippe Rousseau-Lambert
 #           <louis-philippe.rousseaulambert@ec.gc.ca>
 #
-# Copyright (c) 2021 Louis-Philippe Rousseau-Lambert
+# Copyright (c) 2022 Louis-Philippe Rousseau-Lambert
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -416,6 +416,13 @@ class CanGRDProvider(BaseProvider):
                 ]
 
             out_meta['units'] = _data.units
+
+            self.filename = self.data.split('/')[-1]
+            if 'trend' not in self.data and datetime_:
+                self.filename = self.filename.split('_')
+                self.filename[-1] = '{}.tif'.format(
+                    datetime_.replace('/', '-'))
+                self.filename = '_'.join(self.filename)
 
             # CovJSON output does not support multiple bands yet
             # Only the first timestep is returned

--- a/msc_pygeoapi/provider/cansips_rasterio.py
+++ b/msc_pygeoapi/provider/cansips_rasterio.py
@@ -3,7 +3,7 @@
 # Authors: Louis-Philippe Rousseau-Lambert
 #           <louis-philippe.rousseaulambert@ec.gc.ca>
 #
-# Copyright (c) 2021 Louis-Philippe Rousseau-Lambert
+# Copyright (c) 2022 Louis-Philippe Rousseau-Lambert
 #
 
 # Permission is hereby granted, free of charge, to any person
@@ -406,6 +406,8 @@ class CanSIPSProvider(BaseProvider):
                 ]
 
             out_meta['units'] = self._data.units
+
+            self.filename = self.data.split('/')[-1]
 
             # CovJSON output does not support multiple bands yet
             # Only the first timestep is returned

--- a/msc_pygeoapi/provider/climate_xarray.py
+++ b/msc_pygeoapi/provider/climate_xarray.py
@@ -3,7 +3,7 @@
 # Authors: Louis-Philippe Rousseau-Lambert
 #          <louis-philippe.rousseaulambert@ec.gc.ca>
 #
-# Copyright (c) 2021 Louis-Philippe Rousseau-Lambert
+# Copyright (c) 2022 Louis-Philippe Rousseau-Lambert
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -77,6 +77,7 @@ class ClimateProvider(XarrayProvider):
                 self.axes.append('P20Y-Avg')
 
             self.fields = self._coverage_properties['fields']
+
         except Exception as err:
             LOGGER.warning(err)
             raise ProviderConnectionError(err)
@@ -541,6 +542,9 @@ class ClimateProvider(XarrayProvider):
                     data.coords[self.time_field].values[-1])
             ]
             out_meta['time_steps'] = data.dims[self.time_field]
+
+        self.filename = self.data.split('/')[-1].replace(
+            '*', '-'.join(range_subset))
 
         LOGGER.debug('Serializing data in memory')
         if format_ == 'json':

--- a/msc_pygeoapi/provider/rdpa_rasterio.py
+++ b/msc_pygeoapi/provider/rdpa_rasterio.py
@@ -3,7 +3,7 @@
 # Authors: Louis-Philippe Rousseau-Lambert
 #           <louis-philippe.rousseaulambert@ec.gc.ca>
 #
-# Copyright (c) 2021 Louis-Philippe Rousseau-Lambert
+# Copyright (c) 2022 Louis-Philippe Rousseau-Lambert
 #
 
 # Permission is hereby granted, free of charge, to any person
@@ -383,6 +383,9 @@ class RDPAProvider(BaseProvider):
                 ]
 
             out_meta['units'] = _data.units
+
+            self.filename = self.data.split('/')[-1].replace(
+                '*', '')
 
             # CovJSON output does not support multiple bands yet
             # Only the first timestep is returned

--- a/msc_pygeoapi/provider/spei_xarray.py
+++ b/msc_pygeoapi/provider/spei_xarray.py
@@ -3,7 +3,7 @@
 # Authors: Louis-Philippe Rousseau-Lambert
 #          <louis-philippe.rousseaulambert@ec.gc.ca>
 #
-# Copyright (c) 2021 Louis-Philippe Rousseau-Lambert
+# Copyright (c) 2022 Louis-Philippe Rousseau-Lambert
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -220,6 +220,8 @@ class SPEIProvider(ClimateProvider):
             "variables": {var_name: var.attrs
                           for var_name, var in data.variables.items()}
         }
+
+        self.filename = self.data.split('/')[-1]
 
         LOGGER.debug('Serializing data in memory')
         if format_ == 'json':


### PR DESCRIPTION
This merge request add supports for the custom output filename for OGC API - Coverage.

The output filenema uses the data field in the configuration file.

cc @kngai 