### PR TITLE
[BUGFIX] update GRIB2 provider to use a higher number of bytes for the data

### DIFF
--- a/msc_pygeoapi/provider/cansips_rasterio.py
+++ b/msc_pygeoapi/provider/cansips_rasterio.py
@@ -266,6 +266,8 @@ class CanSIPSProvider(BaseProvider):
         :returns: coverage data as dict of CoverageJSON or native format
         """
 
+        nbits = 20
+
         if len(range_subset) > 1:
             err = 'Only one range-subset value is supported'
             LOGGER.error(err)
@@ -430,7 +432,7 @@ class CanSIPSProvider(BaseProvider):
                 LOGGER.debug('Serializing data in memory')
                 out_meta.update(count=len(args['indexes']))
                 with MemoryFile() as memfile:
-                    with memfile.open(**out_meta) as dest:
+                    with memfile.open(**out_meta, nbits=nbits) as dest:
                         dest.write(out_image)
 
                     # return data in native format

--- a/msc_pygeoapi/provider/rdpa_rasterio.py
+++ b/msc_pygeoapi/provider/rdpa_rasterio.py
@@ -258,6 +258,8 @@ class RDPAProvider(BaseProvider):
         :returns: coverage data as dict of CoverageJSON or native format
         """
 
+        nbits = 16
+
         bands = range_subset
         LOGGER.debug('Bands: {}, subsets: {}'.format(bands, subsets))
 
@@ -430,7 +432,7 @@ class RDPAProvider(BaseProvider):
 
                     LOGGER.debug('Serializing data in memory')
                     with MemoryFile() as memfile:
-                        with memfile.open(**out_meta) as dest:
+                        with memfile.open(**out_meta, nbits=nbits) as dest:
                             for id, layer in enumerate(date_file_list,
                                                        start=1):
                                 with rasterio.open(layer) as src1:
@@ -462,7 +464,7 @@ class RDPAProvider(BaseProvider):
                     LOGGER.debug('Serializing data in memory')
                     out_meta.update(count=len(args['indexes']))
                     with MemoryFile() as memfile:
-                        with memfile.open(**out_meta) as dest:
+                        with memfile.open(**out_meta, nbits=nbits) as dest:
                             dest.write(out_image)
 
                         # return data in native format


### PR DESCRIPTION
BUGFIX, this should be backported to the latest tag

Update GRIB2 provider to use a higher number of bytes for the data

see issue 429.

For CANSIPS I am using the original data number of bytes (20) and for RDPA, I am using 16 as agreed with Vincent Fortin in issue 429.

cc @alexandreleroux 