### PR TITLE
ensure stations SQL is inclusive of inputted date passed via CLI

### DIFF
--- a/msc_pygeoapi/loader/climate_archive.py
+++ b/msc_pygeoapi/loader/climate_archive.py
@@ -942,7 +942,7 @@ class ClimateArchiveLoader(BaseLoader):
                         (
                             f"select * from CCCS_PORTAL.PUBLIC_HOURLY_DATA "
                             f"where STN_ID={station} and "
-                            f"LOCAL_DATE > TO_TIMESTAMP('{date} 00:00:00', "
+                            f"LOCAL_DATE >= TO_TIMESTAMP('{date} 00:00:00', "
                             f"'YYYY-MM-DD HH24:MI:SS')"
                         )
                     )


### PR DESCRIPTION
This ensures that the climate archive hourly index CLI command is inclusive of the date passed via the `--date` flag. Prior to this any record for YYYY-MM-DD 00:00:00 was not being fetched prior to indexing. 

Sample CLI command that triggered the issue:
```
msc-pygeoapi data climate-archive add --db <db_string> --es http://localhost:9200 --dataset hourly --date $(date -d '-1day' +"%Y-%m-%d") --station 55138
```

This ensure that the record associated to the `--date` value is included in the indexing.

CC @adanb13.