### PR TITLE
Wrong values when no CAPE

### DIFF
--- a/msc_pygeoapi/process/weather/extract_sounding_data.py
+++ b/msc_pygeoapi/process/weather/extract_sounding_data.py
@@ -416,6 +416,10 @@ def extract_sounding_data(
                     output['properties'][index][desc] = xarray.open_rasterio(
                         full_path
                     )[0, y, x].data.item()
+                    if index in ['CAPE', 'LFC', 'EL'] and output['properties'][index][desc] < 0:  # noqa
+                        output['properties'][index][desc] = '-'
+                    elif index == 'CIN' and output['properties'][index][desc] > 0:  # noqa
+                        output['properties'][index][desc] = '-'
                 else:
                     output['properties'][index][desc] = 'N/A'
 


### PR DESCRIPTION
LFC and EL return -300, CAPE returns -1 and CIN returns 1 when there is no CAPE. Just added a bit of code to change it to '-' so that people using the process aren't confused.