### PR TITLE
update GRIB2 provider to use encoding IEEE_FLOATING_POINT

### DIFF
--- a/msc_pygeoapi/provider/cansips_rasterio.py
+++ b/msc_pygeoapi/provider/cansips_rasterio.py
@@ -420,7 +420,7 @@ class CanSIPSProvider(BaseProvider):
             # Only the first timestep is returned
             if format_ == 'json':
 
-                if '/' in datetime_:
+                if datetime_ and '/' in datetime_:
                     err = 'Date range not yet supported for CovJSON output'
                     LOGGER.error(err)
                     raise ProviderQueryError(err)
@@ -431,6 +431,7 @@ class CanSIPSProvider(BaseProvider):
             else:
                 LOGGER.debug('Serializing data in memory')
                 out_meta.update(count=len(args['indexes']))
+                out_meta.update(DATA_ENCODING='IEEE_FLOATING_POINT')
                 with MemoryFile() as memfile:
                     with memfile.open(**out_meta, nbits=nbits) as dest:
                         dest.write(out_image)

--- a/msc_pygeoapi/provider/rdpa_rasterio.py
+++ b/msc_pygeoapi/provider/rdpa_rasterio.py
@@ -427,6 +427,7 @@ class RDPAProvider(BaseProvider):
                     out_meta['bands'] = [1]
                     return self.gen_covjson(out_meta, out_image)
             else:
+                out_meta.update(DATA_ENCODING='IEEE_FLOATING_POINT')
                 if date_file_list:
                     out_meta.update(count=len(date_file_list))
 


### PR DESCRIPTION
We had issue where the precision of the float were not the same in the json and GRIB2 answers, the solution is to update the GRIB2 provider to use DATA_ENCODING="IEEE_FLOATING_POINT" for float precision

see msc-geomet issue 492