### PR TITLE
zarr provider: support for nearest match

### DIFF
--- a/msc_pygeoapi/provider/hrdps_zarr.py
+++ b/msc_pygeoapi/provider/hrdps_zarr.py
@@ -256,6 +256,7 @@ class HRDPSWEonGZarrProvider(BaseProvider):
         var_dims = self._coverage_properties['dimensions']
         query_return = {'method': 'nearest'}
         if not subsets and not bbox and datetime_ is None:
+            del query_return['method']
             for i in reversed(range(1, DEFAULT_LIMIT_JSON+1)):
                 for dim in var_dims:
                     query_return[dim] = i

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ requests
 sqlalchemy
 unicodecsv
 xarray
+dask
+zarr


### PR DESCRIPTION
allows query for 'nearest' values when 'exact' match is not given, providing there are no slice values passed

for UI:

click (point) query, the user would have to input an exact value for lat and lon else the provider will not accept the query.
This allows for user to not have to be exact with the point and click of their mouse and still be provided data to nearest where they clicked for the lat/lon in the dataset