### PR TITLE
ensure graceful error when incorrect datetime format provided to dms provider

### DIFF
--- a/msc_pygeoapi/provider/msc_dms.py
+++ b/msc_pygeoapi/provider/msc_dms.py
@@ -52,6 +52,7 @@ from pygeoapi.provider.base import (
     BaseProvider,
     ProviderConnectionError,
     ProviderQueryError,
+    ProviderInvalidQueryError,
     ProviderItemNotFoundError
 )
 
@@ -360,7 +361,12 @@ class MSCDMSCoreAPIProvider(BaseProvider):
         :returns: `str` of custom formatted datetime
         """
 
-        value = datetime.strptime(datetime_string, '%Y-%m-%dT%H:%M:%SZ')
+        try:
+            value = datetime.strptime(datetime_string, '%Y-%m-%dT%H:%M:%SZ')
+        except ValueError as e:
+            raise ProviderInvalidQueryError(
+                f'Invalid datetime parameter format: {e}'
+            )
 
         return value.strftime(self.time_field_format)
 


### PR DESCRIPTION
This PR ensures a graceful error is returned to the user when an non RFC 3339-compliant datetime is passed to the DMS Core API provider via the `datetime` parameter.