### PR TITLE
ensure dms provider passes on locationField when bbox parameter provided

### DIFF
--- a/msc_pygeoapi/provider/msc_dms.py
+++ b/msc_pygeoapi/provider/msc_dms.py
@@ -76,6 +76,7 @@ class MSCDMSCoreAPIProvider(BaseProvider):
 
         self.time_field_format = provider_def.get('_time_field_format',
                                                   '%Y%m%d%H%M')
+        self.geom_field = provider_def.get('geom_field', 'location')
 
         LOGGER.debug(f'data: {self.data}')
 
@@ -195,6 +196,7 @@ class MSCDMSCoreAPIProvider(BaseProvider):
 
         if bbox:
             LOGGER.debug('processing bbox')
+            params['locationField'] = self.geom_field
             params['bbox'] = ','.join([str(b) for b in bbox])
 
         if datetime_ is not None:


### PR DESCRIPTION
This PR ensures that a `locationField` parameter, optionally defined in the collection's configuration, is sent along to the DMS Core API when a `bbox` parameter is specifed in a feature collection query. It uses the DMS Core API default of `location` if not specified in the configuration.

