### PR TITLE
ensure datetimeType is masked with properties for datetime queries via DMS Core API provider

### DIFF
--- a/msc_pygeoapi/provider/msc_dms.py
+++ b/msc_pygeoapi/provider/msc_dms.py
@@ -205,7 +205,7 @@ class MSCDMSCoreAPIProvider(BaseProvider):
                 LOGGER.error('time_field not enabled for collection')
                 raise ProviderQueryError()
 
-            params['datetimeType'] = self.time_field
+            params['datetimeType'] = f'properties.{self.time_field}'
 
             if '/' in datetime_:  # envelope
                 LOGGER.debug('detected time range')


### PR DESCRIPTION
Ensure the dateTimeType field is maksed with `properties.` when datetime param is used when querying via DMS Core API provider.