### PR TITLE
restrict dms core api provider sort by on time_field only

### DIFF
--- a/msc_pygeoapi/provider/msc_dms.py
+++ b/msc_pygeoapi/provider/msc_dms.py
@@ -229,6 +229,10 @@ class MSCDMSCoreAPIProvider(BaseProvider):
             LOGGER.debug('processing sortby')
             sort_by_values = []
             for sort in sortby:
+                # only allow sort on time_field
+                if sort['property'] != self.time_field:
+                    msg = f'Sorting only enabled for {self.time_field}'
+                    raise ProviderQueryError(msg)
                 LOGGER.debug(f'processing sort object: {sort}')
                 sort_property = f'{sort["order"]}properties.{sort["property"]}'
                 sort_by_values.append(sort_property)


### PR DESCRIPTION
This PR ensures that a feature collection with the DMS Core API provider has its query `sortby` parameter restricted to the `time_field` defined in the collection's provider definition, given limitations on sort text properties fo the time being.