### PR TITLE
Ensure mappings use RFC 3339 compliant date formats

### DIFF
--- a/msc_pygeoapi/loader/ahccd.py
+++ b/msc_pygeoapi/loader/ahccd.py
@@ -145,7 +145,10 @@ class AhccdLoader(BaseLoader):
                                     "type": "text",
                                     "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "year__annee": {"type": "integer"},
+                                "year__annee": {
+                                    "type": "date",
+                                    "format": "yyyy||strict_date_optional_time"
+                                },
                             }
                         },
                         "geometry": {"type": "geo_shape"},
@@ -166,7 +169,8 @@ class AhccdLoader(BaseLoader):
                             "properties": {
                                 "date": {
                                     "type": "date",
-                                    "format": "yyyy-MM||yyyy",
+                                    "format":
+                                        "yyyy-MM||strict_date_optional_time",
                                 },
                                 "identifier__identifiant": {
                                     "type": "text",
@@ -333,7 +337,10 @@ class AhccdLoader(BaseLoader):
                                     "type": "text",
                                     "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "year__annee": {"type": "integer"},
+                                "year__annee": {
+                                    "type": "date",
+                                    "format": "yyyy||strict_date_optional_time"
+                                },
                             }
                         },
                         "geometry": {"type": "geo_shape"},

--- a/msc_pygeoapi/loader/aqhi_realtime.py
+++ b/msc_pygeoapi/loader/aqhi_realtime.py
@@ -86,7 +86,7 @@ MAPPINGS = {
                     },
                     'publication_datetime': {
                         'type': 'date',
-                        'format': 'strict_date_time_no_millis',
+                        'format': 'strict_date_time_no_millis||strict_date_optional_time',  # noqa
                     },
                     'forecast_datetime_text_en': {
                         'type': 'text',
@@ -133,7 +133,7 @@ MAPPINGS = {
                     },
                     'observation_datetime': {
                         'type': 'date',
-                        'format': 'strict_date_time_no_millis',
+                        'format': 'strict_date_time_no_millis||strict_date_optional_time',  # noqa
                     },
                     'observation_datetime_text_en': {
                         'type': 'text',

--- a/msc_pygeoapi/loader/bulletins_realtime.py
+++ b/msc_pygeoapi/loader/bulletins_realtime.py
@@ -65,7 +65,7 @@ SETTINGS = {
                 'properties': {
                     'datetime': {
                         'type': 'date',
-                        'format': 'strict_date_hour_minute'
+                        'format': 'strict_date_hour_minute||strict_date_optional_time'  # noqa
                     }
                 }
             }

--- a/msc_pygeoapi/loader/climate_archive.py
+++ b/msc_pygeoapi/loader/climate_archive.py
@@ -276,7 +276,7 @@ class ClimateArchiveLoader(BaseLoader):
                                 },
                                 "DATE_CALCULATED": {
                                     "type": "date",
-                                    "format": "yyyy-MM-dd HH:mm:ss",
+                                    "format": "yyyy-MM-dd HH:mm:ss||strict_date_optional_time",  # noqa
                                 },
                             }
                         },
@@ -363,7 +363,7 @@ class ClimateArchiveLoader(BaseLoader):
                                 },
                                 "LOCAL_DATE": {
                                     "type": "date",
-                                    "format": "yyyy-MM",
+                                    "format": "yyyy-MM||strict_date_optional_time",  # noqa
                                 },
                             }
                         },
@@ -478,7 +478,7 @@ class ClimateArchiveLoader(BaseLoader):
                                 "LOCAL_DAY": {"type": "integer"},
                                 "LOCAL_DATE": {
                                     "type": "date",
-                                    "format": "yyyy-MM-dd HH:mm:ss",
+                                    "format": "yyyy-MM-dd HH:mm:ss||strict_date_optional_time",  # noqa
                                 },
                             }
                         },
@@ -585,7 +585,7 @@ class ClimateArchiveLoader(BaseLoader):
                                 "LOCAL_HOUR": {"type": "integer"},
                                 "LOCAL_DATE": {
                                     "type": "date",
-                                    "format": "yyyy-MM-dd HH:mm:ss",
+                                    "format": "yyyy-MM-dd HH:mm:ss ||strict_date_optional_time",  # noqa
                                 },
                                 "UTC_YEAR": {"type": "integer"},
                                 "UTC_MONTH": {"type": "integer"},

--- a/msc_pygeoapi/loader/hydat.py
+++ b/msc_pygeoapi/loader/hydat.py
@@ -143,7 +143,7 @@ class HydatLoader(BaseLoader):
                                 "LEVEL": {"type": "float"},
                                 "DATE": {
                                     "type": "date",
-                                    "format": "yyyy-MM-dd",
+                                    "format": "yyyy-MM-dd||strict_date_optional_time",  # noqa
                                 },
                             }
                         },
@@ -179,7 +179,7 @@ class HydatLoader(BaseLoader):
                                     "type": "text",
                                     "fields": {"raw": {"type": "keyword"}},
                                 },
-                                "DATE": {"type": "date", "format": "yyyy-MM"},
+                                "DATE": {"type": "date", "format": "yyyy-MM||strict_date_optional_time"},  # noqa
                                 "MONTHLY_MEAN_DISCHARGE": {"type": "float"},
                                 "MONTHLY_MEAN_LEVEL": {"type": "float"},
                             }
@@ -223,7 +223,7 @@ class HydatLoader(BaseLoader):
                                 },
                                 "MAX_DATE": {
                                     "type": "date",
-                                    "format": "yyyy-MM-dd",
+                                    "format": "yyyy-MM-dd||strict_date_optional_time",  # noqa
                                 },
                                 "MIN_VALUE": {"type": "float"},
                                 "MAX_VALUE": {"type": "float"},
@@ -339,7 +339,7 @@ class HydatLoader(BaseLoader):
                                 },
                                 "DATE": {
                                     "type": "date",
-                                    "format": "yyyy-MM-dd'T'HH:mm||yyy-MM-dd",
+                                    "format": "yyyy-MM-dd'T'HH:mm||yyyy-MM-dd||strict_date_optional_time",  # noqa
                                 },
                                 "TIMEZONE_OFFSET": {
                                     "type": "text",

--- a/msc_pygeoapi/loader/hydrometric_realtime.py
+++ b/msc_pygeoapi/loader/hydrometric_realtime.py
@@ -99,7 +99,7 @@ SETTINGS = {
                     },
                     'DATETIME': {
                         'type': 'date',
-                        'format': 'strict_date_hour_minute_second'
+                        'format': 'strict_date_hour_minute_second||strict_date_optional_time'  # noqa
                     },
                     'DATETIME_LST': {
                         'type': 'date',

--- a/msc_pygeoapi/loader/metnotes.py
+++ b/msc_pygeoapi/loader/metnotes.py
@@ -66,53 +66,89 @@ MAPPINGS = {
         },
         'properties': {
             'properties': {
-                'id': {'type': 'text', 'fields': {'raw': {'type': 'keyword'}}},
-                'aors': {'type': 'keyword', 'index': 'true'},
-                'type_id': {
-                    'type': 'text',
-                    'fields': {'raw': {'type': 'keyword'}},
-                },
-                'publication_version': {
-                    'type': 'integer',
-                },
-                'start_datetime': {
-                    'type': 'date',
-                    'format': "YYYY-MM-DD'T'HH:mm:ss.SSS'Z'",
-                },
-                'end_datetime': {
-                    'type': 'date',
-                    'format': "YYYY-MM-DD'T'HH:mm:ss.SSS'Z'",
-                },
-                'expiration_datetime': {
-                    'type': 'date',
-                    'format': "YYYY-MM-DD'T'HH:mm:ss.SSS'Z'",
-                },
-                'publication_datetime': {
-                    'type': 'date',
-                    'format': "YYYY-MM-DD'T'HH:mm:ss.SSS'Z'",
-                },
-                'metnote_status': {
-                    'type': 'text',
-                    'fields': {'raw': {'type': 'keyword'}},
-                },
-                'filename': {
-                    'type': 'text',
-                    'fields': {'raw': {'type': 'keyword'}},
-                },
-                'weather_narrative_id': {
-                    'type': 'text',
-                    'fields': {'raw': {'type': 'keyword'}},
-                },
-                'weather_narrative_version': {
-                    'type': 'integer',
-                },
-                'content_en': {
-                    'type': 'text',
-                    'fields': {'raw': {'type': 'keyword'}},
-                },
-                'content_fr': {
-                    'type': 'text',
-                    'fields': {'raw': {'type': 'keyword'}},
+                'properties': {
+                    'id': {
+                        'type': 'text',
+                        'fields': {
+                            'raw': {
+                                'type': 'keyword'
+                            }
+                        }
+                    },
+                    'aors': {
+                        'type': 'keyword',
+                        'index': 'true'
+                    },
+                    'type_id': {
+                        'type': 'text',
+                        'fields': {
+                            'raw': {
+                                'type': 'keyword'
+                            }
+                        }
+                    },
+                    'publication_version': {
+                        'type': 'integer',
+                    },
+                    'start_datetime': {
+                        'type': 'date',
+                        'format': 'strict_date_time_no_millis||strict_date_optional_time'  # noqa
+                    },
+                    'end_datetime': {
+                        'type': 'date',
+                        'format': 'strict_date_time_no_millis||strict_date_optional_time'  # noqa
+                    },
+                    'expiration_datetime': {
+                        'type': 'date',
+                        'format': 'strict_date_time_no_millis||strict_date_optional_time'  # noqa
+                    },
+                    'publication_datetime': {
+                        'type': 'date',
+                        'format': 'strict_date_time_no_millis||strict_date_optional_time'  # noqa
+                    },
+                    'metnote_status': {
+                        'type': 'text',
+                        'fields': {
+                            'raw': {
+                                'type': 'keyword'
+                            }
+                        }
+                    },
+                    'filename': {
+                        'type': 'text',
+                        'fields': {
+                            'raw': {
+                                'type': 'keyword'
+                            }
+                        }
+                    },
+                    'weather_narrative_id': {
+                        'type': 'text',
+                        'fields': {
+                            'raw': {
+                                'type': 'keyword'
+                            }
+                        }
+                    },
+                    'weather_narrative_version': {
+                        'type': 'integer',
+                    },
+                    'content_en': {
+                        'type': 'text',
+                        'fields': {
+                            'raw': {
+                                'type': 'keyword'
+                            }
+                        }
+                    },
+                    'content_fr': {
+                        'type': 'text',
+                        'fields': {
+                            'raw': {
+                                'type': 'keyword'
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR ensures that all loaders use RFC 3339-compliant date formats for properties used as the `time_field` in their associated collection's respective provider definition. This will allow users to query Elasticsearch-provided collections using valid RFC 3339 datetime values and ranges.

I ensured all existing ES-based feature collections had their mappings extended for the property mentioned in collection's provider definition's `time_field` value.