### PR TITLE
implement index aliasing for ltce loader

### DIFF
--- a/debian/msc-pygeoapi.cron.d
+++ b/debian/msc-pygeoapi.cron.d
@@ -45,5 +45,8 @@
 # every day at 0700h, clean metnotes data older than 7 days
 0 7 * * * geoadm msc-pygeoapi data metnotes clean_indexes --days 7 --yes
 
+# every day at 0800h, clean ltce data older than 3 days
+0 8 * * * geoadm msc-pygeoapi data ltce clean_indexes --days 3 --yes
+
 # every day at 0300h, clean out empty MetPX directories
 0 3 * * * geoadm /usr/bin/find $MSC_PYGEOAPI_CACHEDIR -type d -empty -delete > /dev/null 2>&1

--- a/msc_pygeoapi/util.py
+++ b/msc_pygeoapi/util.py
@@ -145,25 +145,27 @@ def generate_datetime_range(start, end, delta):
         current += delta
 
 
-def check_es_indexes_to_delete(indexes, days):
+def check_es_indexes_to_delete(
+    indexes, days, pattern='{index_name}.{year:d}-{month:d}-{day:d}'
+):
     """
     helper function to determine ES indexes that are older than a certain date
 
     :param indexes: list of ES index names
     :param days: number of days used to determine deletion criteria
+    :param pattern: pattern used to parse index name
+                    (default: {index_name}.{year:d}-{month:d}-{day:d})
 
     :returns: list of indexes to delete
     """
 
     today = datetime.utcnow()
-    pattern = '{index_name}.{YYYY:d}-{MM:d}-{dd:d}'
     to_delete = []
 
     for index in indexes:
         parsed = parse(pattern, index)
-        index_date = datetime(
-            parsed.named['YYYY'], parsed.named['MM'], parsed.named['dd']
-        )
+        parsed.named.pop('index_name')
+        index_date = datetime(**parsed.named)
         if index_date < (today - timedelta(days=days)):
             to_delete.append(index)
 


### PR DESCRIPTION
This PR implements a new date-based index management approach for LTCE indices. It uses [Elasticsearch aliases](https://www.elastic.co/guide/en/elasticsearch/reference/current/aliases.html) to reference the latest successfully loaded data via a generic index name (i.e `ltce_temp_extremes` points to `ltce_temp_extremes.2023-03-03.205131`). This helps avoid instances where data would fail to be properly loaded from the data source resulting in data unavailability.

Changes were also made to the `msc_pygeoapi.util.check_es_indexes_to_delete()` method to accept a passed pattern keyword argument (keeping `{index_name}.{year:d}-{month:d}-{day:d}`) as default). This is needed since LTCE data is loaded twice daily.