### PR TITLE
Change docker deploy script to use master branch

### DIFF
--- a/deploy/nightly/deploy-nightly-docker.sh
+++ b/deploy/nightly/deploy-nightly-docker.sh
@@ -57,8 +57,7 @@ echo "Generating nightly build for $TIMESTAMP"
 mkdir $NIGHTLYDIR && cd $NIGHTLYDIR
 
 echo "Cloning Git repository"
-# git clone $MSC_PYGEOAPI_GITREPO . -b master --depth=1
-git clone $MSC_PYGEOAPI_GITREPO . -b nightly-focal --depth=1
+git clone $MSC_PYGEOAPI_GITREPO . -b master --depth=1
 
 echo "Stopping/building/starting Docker setup"
 docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml down


### PR DESCRIPTION
Quick fix to ensure deploy script is using the `master` branch, now that the Docker build is in `master`.