### PR TITLE
Add locale_dir config to ensure locale path is correct

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,8 +80,6 @@ RUN cd msc-pygeoapi && \
     sed -i "s/MSC_PYGEOAPI_VERSION/$MSC_PYGEOAPI_VERSION/" theme/templates/_base.html && \
     # ensure i18n translation strings are compiled
     pybabel compile -d locale -l fr && \
-    # /locale directory required at WORKDIR to ensure working i18n of Jinja2 HTML templates
-    cp -r ./locale $BASEDIR/locale && \
     cd ..
 
 # cleanup apt/build deps

--- a/deploy/default/msc-pygeoapi-config.yml
+++ b/deploy/default/msc-pygeoapi-config.yml
@@ -9,6 +9,7 @@ server:
     languages:
         - en-CA
         - fr-CA
+    locale_dir: ${MSC_PYGEOAPI_LOCALE}
     # cors: true
     pretty_print: false
     limit: 500

--- a/docker/default.env
+++ b/docker/default.env
@@ -13,6 +13,7 @@ MSC_PYGEOAPI_ES_TIMEOUT=90
 MSC_PYGEOAPI_CACHEDIR=/tmp
 MSC_PYGEOAPI_TEMPLATES=${BASEDIR}/msc-pygeoapi/theme/templates
 MSC_PYGEOAPI_STATIC=${BASEDIR}/msc-pygeoapi/theme/static
+MSC_PYGEOAPI_LOCALE=${BASEDIR}/msc-pygeoapi/locale
 
 GEOMET_HPFX_BASEPATH=/data/geomet/feeds/hpfx
 GEOMET_SCIENCE_BASEPATH=/data/geomet/feeds/cmoi-science

--- a/msc-pygeoapi.env
+++ b/msc-pygeoapi.env
@@ -12,7 +12,7 @@ export MSC_PYGEOAPI_METPX_EVENT_FILE_PY=/opt/msc-pygeoapi/event/file_.py
 export MSC_PYGEOAPI_METPX_EVENT_MESSAGE_PY=/opt/msc-pygeoapi/event/message.py
 export MSC_PYGEOAPI_TEMPLATES=theme/templates
 export MSC_PYGEOAPI_STATIC=theme/static
-
+export MSC_PYGEOAPI_LOCALE=locale
 export MSC_PYGEOAPI_DMS_API_URL=http://host/search/v2.0
 
 export GEOMET_HPFX_BASEPATH=/data/geomet/feeds/hpfx


### PR DESCRIPTION
This PR makes use of the `locale_dir` config in the `-config.yml` to ensure the path to the locale folder is correct. Added `$MSC_PYGEOAPI_LOCALE` as an env variable to adjust. Default value is `locale`, relative to the code repo.