### PR TITLE
clamp datetime for certain ES-based collections

### DIFF
--- a/deploy/default/msc-pygeoapi-config.yml
+++ b/deploy/default/msc-pygeoapi-config.yml
@@ -429,7 +429,7 @@ resources:
         providers:
             - type: feature
               default: true
-              name: Elasticsearch
+              name: msc_pygeoapi.provider.elasticsearch.MSCElasticsearchProvider
               data: ${MSC_PYGEOAPI_ES_URL}/hydrometric_annual_peaks
               id_field: IDENTIFIER
               time_field: DATE
@@ -642,7 +642,7 @@ resources:
         providers:
             - type: feature
               default: true
-              name: Elasticsearch
+              name: msc_pygeoapi.provider.elasticsearch.MSCElasticsearchProvider
               data: ${MSC_PYGEOAPI_ES_URL}/climate_public_climate_summary
               id_field: ID
               time_field: LOCAL_DATE
@@ -902,7 +902,7 @@ resources:
         providers:
             - type: feature
               default: true
-              name: Elasticsearch
+              name: msc_pygeoapi.provider.elasticsearch.MSCElasticsearchProvider
               data: ${MSC_PYGEOAPI_ES_URL}/ahccd_annual
               id_field: identifier__identifiant
               time_field: year__annee
@@ -969,7 +969,7 @@ resources:
         providers:
             - type: feature
               default: true
-              name: Elasticsearch
+              name: msc_pygeoapi.provider.elasticsearch.MSCElasticsearchProvider
               data: ${MSC_PYGEOAPI_ES_URL}/ahccd_seasonal
               id_field: identifier__identifiant
               time_field: year__annee
@@ -1036,7 +1036,7 @@ resources:
         providers:
             - type: feature
               default: true
-              name: Elasticsearch
+              name: msc_pygeoapi.provider.elasticsearch.MSCElasticsearchProvider
               data: ${MSC_PYGEOAPI_ES_URL}/ahccd_monthly
               id_field: identifier__identifiant
               time_field: date

--- a/msc_pygeoapi/provider/elasticsearch.py
+++ b/msc_pygeoapi/provider/elasticsearch.py
@@ -27,11 +27,135 @@
 #
 # =================================================================
 
+from datetime import datetime
 import logging
 
-from pygeoapi.provider.elasticsearch_ import ElasticsearchCatalogueProvider
+from pygeoapi.provider.elasticsearch_ import (
+    ElasticsearchProvider,
+    ElasticsearchCatalogueProvider
+)
+
+from msc_pygeoapi.util import DATETIME_RFC3339_FMT
 
 LOGGER = logging.getLogger(__name__)
+
+
+class MSCElasticsearchProvider(ElasticsearchProvider):
+    """MSC Elasticsearch Provider"""
+
+    def __init__(self, provider_def):
+        """
+        Initialize object
+
+        :param provider_def: provider definition
+
+        :returns: msc_pygeoapi.provider.elasticsearch_.MSCElasticsearchProvider
+        """
+
+        super().__init__(provider_def)
+
+    def _get_timefield_format(self):
+        """
+        Retrieve time_field format from ES index mapping
+
+        :returns: `str` of time_field format
+        """
+        mapping = self.es.indices.get_mapping(index=self.index_name)
+        p = mapping[self.index_name]['mappings']['properties']['properties']
+
+        format_ = p['properties'][self.time_field].get('format')
+
+        if format_ and '||' in format_:
+            format_ = format_.split('||')[0]
+
+        LOGGER.debug(f'time_field format: {format_}')
+
+        return format_
+
+    def _clamp_datetime(self, datetime_, timefield_format):
+        """
+        Clamp datetime to timefield_format
+
+        :param datetime: `datetime` object
+        :param timefield_format: time_field format retrieved from Elasticsearch
+
+        :returns: clamped `datetime` object
+        """
+
+        time_patterns_replace = {
+            'yyyy': dict(
+                month=1, day=1, hour=0, minute=0, second=0, microsecond=0
+            ),
+            'yyyy-MM': dict(day=1, hour=0, minute=0, second=0, microsecond=0),
+            'yyyy-MM-dd': dict(hour=0, minute=0, second=0, microsecond=0),
+            "yyyy-MM-dd'T'HH": dict(minute=0, second=0, microsecond=0),
+            "yyyy-MM-dd'T'HH:mm": dict(second=0, microsecond=0),
+            "yyyy-MM-dd'T'HH:mm:ss'Z'": dict(microsecond=0)
+        }
+
+        if timefield_format not in time_patterns_replace:
+            LOGGER.warning(
+                'Unrecognized time_field format. Skipping clamping.'
+            )
+            return datetime_
+
+        return datetime_.replace(**time_patterns_replace[timefield_format])
+
+    def _get_clamped_datetime_range(self, datetime_):
+        """
+        Return clamped datetime range or instant from RFC 3339 datetime string
+
+        :param datetime_: `str` datetime range or instant in RFC 3339 format
+
+        :returns: `tuple` of `datetime.datetime` objects
+        """
+        if '/' in datetime_:
+            LOGGER.debug('detected time range')
+            time_begin, time_end = [
+                datetime.strptime(time, DATETIME_RFC3339_FMT)
+                for time in datetime_.split('/')
+            ]
+            return (
+                self._clamp_datetime(time_begin, self.timefield_format),
+                self._clamp_datetime(time_end, self.timefield_format)
+            )
+        else:
+            LOGGER.debug('detected time instant')
+            time = datetime.strptime(datetime_, DATETIME_RFC3339_FMT)
+            return (self._clamp_datetime(time, self.timefield_format),)
+
+    def query(self, *args, **kwargs):
+
+        if kwargs.get('datetime_'):
+            self.timefield_format = self._get_timefield_format()
+
+            if not self.timefield_format:
+                LOGGER.warning(
+                    'Could not retrieve time_field format from index '
+                    'mapping. Skipping time clamping.'
+                )
+                return super().query(*args, **kwargs)
+
+            try:
+                clamped_datetime_range = self._get_clamped_datetime_range(
+                    kwargs['datetime_']
+                )
+                kwargs['datetime_'] = '/'.join(
+                    [
+                        datetime_.strftime(DATETIME_RFC3339_FMT)
+                        for datetime_ in clamped_datetime_range
+                    ]
+                )
+            except ValueError:
+                LOGGER.warning(
+                    'Invalid RFC 3339 datetime format received. '
+                    'Skipping time clamping.'
+                )
+
+        return super().query(*args, **kwargs)
+
+    def __repr__(self):
+        return f'<MSCElasticsearchProvider> {self.data}'
 
 
 class ElasticsearchCatalogueWMOWIS2GDCProvider(ElasticsearchCatalogueProvider):


### PR DESCRIPTION
This MR addresses an issue where when supplying an RFC 3339  `datetime` value or range for ES-based collections the returned result would be missing certain items when a collection's `time_field` property is not defined down to a precise temporal resolution (i.e `yyyy`, `yyyy-mm`, etc.).

When the `MSCElasticsearchProvider` has its `query()` method called and contains a `datetime_` value, the `time_field`'s  format is retrieved from Elasticsearch from the relevant index's mapping. This value is then used to apply a clamping of the datetime elements to the temporal resolution defined by the field format.

For example, given a time_field with format `yyyy-mm`,  a user makes a request with `&datetime=2023-03-15T00:00:00Z`. Currently, the results would not contain any features with a time_field value of `2023-03` (since Elasticsearch maps this as `2023-03-01T00:00:00` which does not match value provided). With the proposed changes the datetime would be clamped to `2023-03-01T00:00:00Z` and would return all documents with a time_field value of `2023-03`.

