### PR TITLE
add UTC date fields to climate-hourly collection

### DIFF
--- a/deploy/default/msc-pygeoapi-config.yml
+++ b/deploy/default/msc-pygeoapi-config.yml
@@ -804,6 +804,10 @@ resources:
                   - LOCAL_MONTH
                   - LOCAL_DAY
                   - LOCAL_HOUR
+                  - UTC_DATE
+                  - UTC_YEAR
+                  - UTC_MONTH
+                  - UTC_DAY
                   - TEMP
                   - TEMP_FLAG
                   - DEW_POINT_TEMP


### PR DESCRIPTION
This MR adds the following fields to the available climate-hourly collection's properties: `UTC_DATE`, `UTC_YEAR`, `UTC_MONTH`, `UTC_DAY`.