### PR TITLE
Add docker restart policy

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,6 +31,7 @@ services:
   msc-pygeoapi:
     image: eccc-msc/msc-pygeoapi:nightly
     container_name: msc-pygeoapi-nightly
+    restart: unless-stopped
     build: 
       context: ..
     network_mode: host


### PR DESCRIPTION
This PR adds an auto restart policy for the docker container to address our scheduled server downtime or restarts.