### PR TITLE
rlat and rlon reprojection

### DIFF
--- a/msc_pygeoapi/provider/hrdps_zarr.py
+++ b/msc_pygeoapi/provider/hrdps_zarr.py
@@ -334,12 +334,14 @@ class HRDPSWEonGZarrProvider(BaseProvider):
                 LOGGER.debug(f'data_vals in bbox: {data_vals}')
             else:
                 # is a xarray data-array
+                LOGGER.info(f'query_return: {query_return}')
                 data_vals = self._data.sel(**query_return)
                 LOGGER.debug(f'data_vals: {data_vals}')
-        except Exception as e:
-            msg = f'Invalid query (Error: {e})'
+        except Exception:
+            # most likely invalid time or subset value
+            msg = 'Invalid query: No data found'
             LOGGER.error(msg)
-            raise ProviderInvalidQueryError(msg)
+            raise ProviderNoDataError(msg)
 
         if data_vals.values.size == 0:
             try:
@@ -348,11 +350,11 @@ class HRDPSWEonGZarrProvider(BaseProvider):
                     single_query['rlat'] = query_return['rlat'].start
                 if query_return['rlon'].start == query_return['rlon'].stop:
                     single_query['rlon'] = query_return['rlon'].start
-
+                LOGGER.info(f'Nearest point query: {single_query}')
                 data_vals = self._data.sel(**single_query, method='nearest')
                 new_rlon = data_vals.rlon.values
                 new_rlat = data_vals.rlat.values
-                LOGGER.debug(f'Nearest point returned: {new_rlon}, {new_rlat}')
+                LOGGER.info(f'Nearest point returned: {new_rlon}, {new_rlat}')
                 LOGGER.debug('Nearest point query')
                 for key in query_return.keys():
                     if key == 'time':

--- a/msc_pygeoapi/provider/hrdps_zarr.py
+++ b/msc_pygeoapi/provider/hrdps_zarr.py
@@ -525,9 +525,6 @@ def _convert_subset_to_crs(new_lat: slice, new_lon: slice, crs):
     to_transform = Transformer.from_crs(crs_src, crs_dst, always_xy=True)
     max_sub = to_transform.transform(new_lon.stop, new_lat.stop)
     min_sub = to_transform.transform(new_lon.start, new_lat.start)
-    # if slices are same, it sets min_cub to inf
-    if new_lat == new_lon:
-        return max_sub, max_sub
     LOGGER.debug(f'Max subset: {max_sub}, Min subset: {min_sub}')
     return max_sub, min_sub
 

--- a/msc_pygeoapi/provider/hrdps_zarr.py
+++ b/msc_pygeoapi/provider/hrdps_zarr.py
@@ -369,7 +369,7 @@ class HRDPSWEonGZarrProvider(BaseProvider):
                     query_str = _make_where_str(query_return, single_query)
                     data_vals = data_vals.where(eval(query_str), drop=True)
 
-            except Exception as e:
+            except Exception:
                 # most likely invalid time or subset value
                 msg = 'Invalid query: No data found'
                 LOGGER.error(msg)

--- a/msc_pygeoapi/provider/hrdps_zarr.py
+++ b/msc_pygeoapi/provider/hrdps_zarr.py
@@ -367,7 +367,7 @@ class HRDPSWEonGZarrProvider(BaseProvider):
                 LOGGER.debug(f'Nearest point returned DIMS: {data_vals.dims}')
                 if query_return.keys() != single_query.keys():
                     query_str = _make_where_str(query_return, single_query)
-                    data_vals= data_vals.where(eval(query_str), drop = True)
+                    data_vals = data_vals.where(eval(query_str), drop=True)
 
             except Exception as e:
                 msg = f'Invalid query (Error: {e})'

--- a/msc_pygeoapi/provider/hrdps_zarr.py
+++ b/msc_pygeoapi/provider/hrdps_zarr.py
@@ -370,9 +370,10 @@ class HRDPSWEonGZarrProvider(BaseProvider):
                     data_vals = data_vals.where(eval(query_str), drop=True)
 
             except Exception as e:
-                msg = f'Invalid query (Error: {e})'
+                # most likely invalid time or subset value
+                msg = 'Invalid query: No data found'
                 LOGGER.error(msg)
-                raise ProviderInvalidQueryError(msg)
+                raise ProviderNoDataError(msg)
 
         if data_vals.values.size == 0:
             msg = 'Invalid query: No data found'

--- a/msc_pygeoapi/provider/hrdps_zarr.py
+++ b/msc_pygeoapi/provider/hrdps_zarr.py
@@ -372,9 +372,11 @@ class HRDPSWEonGZarrProvider(BaseProvider):
                 if query_return.keys() != single_query.keys():
                     query_str = _make_where_str(query_return, single_query)
                     if query_str != '':
-                        data_vals = data_vals.where(eval(query_str), drop=True).sel(time = query_return['time'])
+                        data_vals = data_vals.where(
+                            eval(query_str), drop=True
+                            ).sel(time=query_return['time'])
                     else:
-                        data_vals = data_vals.sel(time = query_return['time'])
+                        data_vals = data_vals.sel(time=query_return['time'])
 
             except Exception as e:
                 # most likely invalid time or subset value
@@ -514,14 +516,14 @@ def _make_where_str(first_query: dict, new_query: dict) -> str:
     :returns: where query string for use in .where()
     """
 
-    query_params = []
+    query_param = []
 
     for key in first_query.keys():
         if key not in new_query.keys():
-            query_params.append(f'(self._data.{key}>={first_query[key].start})')
-            query_params.append(f'(self._data.{key}<={first_query[key].stop})')
+            query_param.append(f'(self._data.{key}>={first_query[key].start})')
+            query_param.append(f'(self._data.{key}<={first_query[key].stop})')
 
-    query_string = ' & '.join(query_params)
+    query_string = ' & '.join(query_param)
     LOGGER.debug(f'Where query string: {query_string}')
     return query_string
 

--- a/msc_pygeoapi/provider/hrdps_zarr.py
+++ b/msc_pygeoapi/provider/hrdps_zarr.py
@@ -280,7 +280,7 @@ class HRDPSWEonGZarrProvider(BaseProvider):
                             msg = 'values must be well-defined range'
                             LOGGER.error(msg)
                             raise ProviderInvalidQueryError(msg)
-                
+
                     else:  # redundant check (done in api.py)
                         msg = f'Invalid Dimension (Dimension {dim} not found)'
                         LOGGER.error(msg)

--- a/msc_pygeoapi/provider/hrdps_zarr.py
+++ b/msc_pygeoapi/provider/hrdps_zarr.py
@@ -525,6 +525,9 @@ def _convert_subset_to_crs(new_lat: slice, new_lon: slice, crs):
     to_transform = Transformer.from_crs(crs_src, crs_dst, always_xy=True)
     max_sub = to_transform.transform(new_lon.stop, new_lat.stop)
     min_sub = to_transform.transform(new_lon.start, new_lat.start)
+    # if slices are same, it sets min_cub to inf
+    if new_lat == new_lon:
+        return max_sub, max_sub
     LOGGER.debug(f'Max subset: {max_sub}, Min subset: {min_sub}')
     return max_sub, min_sub
 


### PR DESCRIPTION
### Changes

- User provides `rlon` and `rlat` in WGS84, provider re-projects using native CRS

### Example Links
_NOTE: Need to use slight range for `rlat/rlon` as `nearest` not yet implemented_

**Toronto**
http://infopool-dev1.cmc.ec.gc.ca:5089/collections/weong:hrdps:tt/coverage?subset=rlon(-79.421371:-72),rlat(43.780918:45),level(1:1)&datetime=2023-03-09T00:00:00.000000000&f=json

**Ottawa**
http://infopool-dev1.cmc.ec.gc.ca:5089/collections/weong:hrdps:tt/coverage?subset=rlon(-75.695000:-74),rlat(43.780918:45),level(1:1)&datetime=2023-03-09T00:00:00.000000000&f=json

**Edmonton**
http://infopool-dev1.cmc.ec.gc.ca:5089/collections/weong:hrdps:tt/coverage?subset=rlon(-113.4937:-112),rlat(53.5461:54),level(1:1)&datetime=2023-03-09T00:00:00.000000000&f=json

**New Brunswick**
http://infopool-dev1.cmc.ec.gc.ca:5089/collections/weong:hrdps:tt/coverage?subset=rlon(-66.159668:-65),rlat(46.498390:47),level(1:1)&datetime=2023-03-09T00:00:00.000000000&f=json

**Prince Edward Island**
http://infopool-dev1.cmc.ec.gc.ca:5089/collections/weong:hrdps:tt/coverage?subset=rlon(-63.000000:-62),rlat(46.250000:47),level(1:1)&datetime=2023-03-09T00:00:00.000000000&f=json

**Yukon**
http://infopool-dev1.cmc.ec.gc.ca:5089/collections/weong:hrdps:tt/coverage?subset=rlon(-131.352539:-130),rlat(62.350357:63),level(1:1)&datetime=2023-03-09T00:00:00.000000000&f=json

### TO DO

- Have Shaheed confirm provider now returns data as required
- implement `nearest` method for point queries
- _(Improvement)_ implement reprojection to `bbox` queries allowing us to use `.sel` instead of `.where` which is much faster and gets rid for the need to use `eval`
- Change CoverageJSON `axes` information to WGS84 user given input instead of current reprojected coordinates being given


