### PR TITLE
Optimization and added functionality

### DIFF
--- a/msc_pygeoapi/provider/hrdps_zarr.py
+++ b/msc_pygeoapi/provider/hrdps_zarr.py
@@ -319,8 +319,8 @@ class HRDPSWEonGZarrProvider(BaseProvider):
             if all([query_return['rlat'].start != query_return['rlat'].stop,
                     query_return['rlon'].start != query_return['rlon'].stop]):
                 LOGGER.info('Spatial subset query')
-                LOGGER.info(f'Rlat start {query_return["rlat"].start}')
-                LOGGER.info(f'Rlat stop {query_return["rlat"].stop}')
+                LOGGER.debug(f'Rlat start {query_return["rlat"].start}')
+                LOGGER.debug(f'Rlat stop {query_return["rlat"].stop}')
                 data_vals = self._data.sel(**query_return)
             else:
                 single_query = {}
@@ -342,24 +342,24 @@ class HRDPSWEonGZarrProvider(BaseProvider):
                         new_rlat = data_vals.rlat.values
                         LOGGER.info(
                             f'Nearest point returned: {new_rlon}, {new_rlat}')
-                        LOGGER.info(f'NEAREST DATA: {data_vals}')
+                        LOGGER.debug(f'NEAREST DATA: {data_vals}')
                     elif 'nolat' in single_query:
                         data_vals = self._data.sel(
                             rlon=single_query['rlon'], method='nearest')
                         new_rlon = data_vals.rlon.values
-                        LOGGER.info(f'New rlon: {new_rlon}')
+                        LOGGER.debug(f'New rlon: {new_rlon}')
                         single_query.pop('nolat')
                         single_query['rlon'] = slice(new_rlon, new_rlon)
                     elif 'nolon' in single_query:
                         data_vals = self._data.sel(
                             rlat=single_query['rlat'], method='nearest')
                         new_rlat = data_vals.rlat.values
-                        LOGGER.info(f'New rlat: {new_rlat}')
+                        LOGGER.debug(f'New rlat: {new_rlat}')
                         single_query.pop('nolon')
                         single_query['rlat'] = slice(new_rlat, new_rlat)
 
                     else:
-                        LOGGER.info('Reseting query')
+                        LOGGER.debug('Reseting query')
                         single_query = {}
                 except Exception as e:
                     msg = f'Nearest point query failed: {e}'
@@ -371,11 +371,11 @@ class HRDPSWEonGZarrProvider(BaseProvider):
                         single_query[key] = query_return[key].start
                     else:
                         new_query[key] = query_return[key]
-                LOGGER.info(f'Nearest point returned: {single_query}')
+                LOGGER.debug(f'Nearest point returned: {single_query}')
                 data_vals = self._data.sel(**single_query, method='nearest')
-                LOGGER.info(f'Nearest point returned DIMS: {data_vals}')
+                LOGGER.debug(f'Nearest point returned DIMS: {data_vals}')
                 data_vals = data_vals.sel(**new_query)
-                LOGGER.info(f'FINAL data_vals: {data_vals}')
+                LOGGER.debug(f'FINAL data_vals: {data_vals}')
 
         except Exception as e:
             # most likely invalid time or subset value

--- a/msc_pygeoapi/provider/hrdps_zarr.py
+++ b/msc_pygeoapi/provider/hrdps_zarr.py
@@ -254,8 +254,6 @@ class HRDPSWEonGZarrProvider(BaseProvider):
 
         var_dims = self._coverage_properties['dimensions']
         query_return = {}
-        is_bbox = False
-        bbox_str = ''
         if not subsets and not bbox and datetime_ is None:
             for i in reversed(range(1, 2)):
                 for dim in var_dims:
@@ -319,11 +317,10 @@ class HRDPSWEonGZarrProvider(BaseProvider):
 
         try:
             if all([query_return['rlat'].start != query_return['rlat'].stop,
-                query_return['rlon'].start != query_return['rlon'].stop]):
+                    query_return['rlon'].start != query_return['rlon'].stop]):
                 LOGGER.info('Spatial subset query')
                 LOGGER.info(f'Rlat start {query_return["rlat"].start}')
                 LOGGER.info(f'Rlat stop {query_return["rlat"].stop}')
-                LOGGER.info(f'{query_return["rlat"].start != query_return["rlat"].stop}')
                 data_vals = self._data.sel(**query_return)
             else:
                 single_query = {}
@@ -339,19 +336,23 @@ class HRDPSWEonGZarrProvider(BaseProvider):
                         single_query['nolon'] = '0'
                     if ('nolat' and 'nolon') not in single_query:
                         LOGGER.info(f'Nearest point query: {single_query}')
-                        data_vals = self._data.sel(**single_query, method='nearest')
+                        data_vals = self._data.sel(
+                            **single_query, method='nearest')
                         new_rlon = data_vals.rlon.values
                         new_rlat = data_vals.rlat.values
-                        LOGGER.info(f'Nearest point returned: {new_rlon}, {new_rlat}')
+                        LOGGER.info(
+                            f'Nearest point returned: {new_rlon}, {new_rlat}')
                         LOGGER.info(f'NEAREST DATA: {data_vals}')
                     elif 'nolat' in single_query:
-                        data_vals = self._data.sel(rlon=single_query['rlon'], method='nearest')
+                        data_vals = self._data.sel(
+                            rlon=single_query['rlon'], method='nearest')
                         new_rlon = data_vals.rlon.values
                         LOGGER.info(f'New rlon: {new_rlon}')
                         single_query.pop('nolat')
                         single_query['rlon'] = slice(new_rlon, new_rlon)
                     elif 'nolon' in single_query:
-                        data_vals = self._data.sel(rlat=single_query['rlat'], method='nearest')
+                        data_vals = self._data.sel(
+                            rlat=single_query['rlat'], method='nearest')
                         new_rlat = data_vals.rlat.values
                         LOGGER.info(f'New rlat: {new_rlat}')
                         single_query.pop('nolon')

--- a/msc_pygeoapi/provider/hrdps_zarr.py
+++ b/msc_pygeoapi/provider/hrdps_zarr.py
@@ -392,10 +392,10 @@ class HRDPSWEonGZarrProvider(BaseProvider):
             new_dataset.attrs['_CRS'] = self.crs
             return _get_zarr_data_stream(new_dataset)
 
-        '''if data_vals.data.nbytes > MAX_DASK_BYTES:
+        if data_vals.data.nbytes > MAX_DASK_BYTES:
             raise ProviderInvalidQueryError(
                 'Data size exceeds maximum allowed size'
-                )'''
+                )
 
         return _gen_covjson(self, the_data=data_vals)
 


### PR DESCRIPTION
**What's new**

- all subset queries now valid using `.nearest` (improvement on current, where only datetime works)
The following is now possible: `subset=rlon(-75.70006815617707:-75.70006815617707),rlat(45.42366341654287:45.42366341654287),level(0.8:1)&datetime=2023-03-09T00:00:00.000000000/2023-03-10T00:00:00.000000000&f=json`

- rid of  helper function `_make_where_str`
- no use of `.eval` and `.where` (replaced with `.sel` for ALL queries, much faster)
- `bbox` now queries same 1 dimensional data-array for `rlat/rlon`  values as providing `rlat/rlon` in `subset` making `bbox` query faster, currently query is preformed over multi-dimensional array (much slower)
The following  and above `subset` are now equivalent with regards to performance: `bbox=-75.70006815617707,45.42366341654287,-75.70006815617707,45.42366341654287&subset=level(0.8:1)&datetime=2023-03-09T00:00:00.000000000/2023-03-10T00:00:00.000000000&f=json`

**TO DO**

- certain reprojections cause errors such as returning `inf` values.
- validate if certain query types work as expected
For Example, the following:
`subset=rlon(-75.70006815617707:-72),rlat(45.42366341654287:45.42366341654287),level(1:1)&datetime=2023-03-09T00:00:00.000000000&f=json` 

provides the shape: `"axisNames": ["time", "level", "rlat", "rlon"], "shape": [1, 1, 96, 149]`

`rlat` is a point so expecting `shape` of 1 for `axisNames` `rlat`. However, `shape` of 96 is provided. 

The transformed coordinates are: ` Max subset: (28.4197813879923, 0.15566888494466388), Min subset: (26.21521631804874, -1.216692757385384)` (`rlon, rlat`)

Expecting `rlat` `min/max` values to be the same as in `subset` same value is provided for both. Yet, getting `(-1.216692757385384, 0.15566888494466388)`. Which may be why resulting data has `shape` 9 instead of 1 for `rlat`