### PR TITLE
rid of dask mask as .where is no longer used

### DIFF
--- a/msc_pygeoapi/provider/hrdps_zarr.py
+++ b/msc_pygeoapi/provider/hrdps_zarr.py
@@ -38,7 +38,6 @@ from pygeoapi.provider.base import (
     ProviderInvalidQueryError,
     ProviderNoDataError
 )
-import dask.array as da
 from pyproj import CRS, Transformer
 from typing import Tuple
 import xarray
@@ -605,10 +604,8 @@ def _gen_covjson(self, the_data):
         )
 
     else:
-        arr = the_data.data.flatten()
-        d_mask = ~da.isnan(arr)
         the_range[parameter_metadata['id'][0]]['values'] = (
-                arr[d_mask].compute().tolist()
+                the_data.data.flatten().compute().data.tolist()
             )
 
     cov_json['ranges'] = the_range

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 click
-dask
 elasticsearch<8
 fiona
 gdal


### PR DESCRIPTION
rid of dask mask as .where is no longer used

improved efficiency by calling `.tolist()` on .`data` instead of on `.compute()`