### PR TITLE
remove setting of the geomet-climate epsg file path

### DIFF
--- a/msc_pygeoapi/process/cccs/__init__.py
+++ b/msc_pygeoapi/process/cccs/__init__.py
@@ -29,7 +29,6 @@
 # =================================================================
 
 import click
-import imp
 import logging
 
 from msc_pygeoapi.process.cccs.raster_drill import raster_drill_execute
@@ -39,16 +38,6 @@ LOGGER = logging.getLogger(__name__)
 GEOMET_CLIMATE_CONFIG = '/opt/geomet-climate/geomet-climate.yml'
 GEOMET_CLIMATE_BASEPATH = '/data/geomet/feeds/dd/climate'
 GEOMET_CLIMATE_BASEPATH_VRT = '/opt/geomet-climate/vrt'
-try:
-    GEOMET_CLIMATE_EPSG = '{}/{}'.format(
-        imp.find_module('geomet_climate')[1], '/resources/mapserv'
-    )
-except ImportError:
-    LOGGER.warning(
-        "Could not import geomet_climate module."
-        " Ensure geomet-climate is installed in order to use cccs processes."
-    )
-    GEOMET_CLIMATE_EPSG = None
 
 
 @click.group()


### PR DESCRIPTION
Remove the setting of `GEOMET_CLIMATE_EPSG` since it is no longer used by the raster drill process (removed via #263).