### PR TITLE
Replace install of geomet-climate with curl of geomet-climate.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,13 +49,8 @@ RUN git clone $PYGEOAPI_GITREPO && \
     python3 setup.py install && \
     cd ..
 
-# install geomet_climate for python module access (and eliminate warnings)
-RUN git clone https://github.com/ECCC-CCCS/geomet-climate.git && \
-    cd geomet-climate && \
-    pip install -r requirements.txt && \
-    pip install -r requirements-dev.txt && \
-    pip install -e . && \
-    cd ..
+# requirement of GEOMET_CLIMATE_CONFIG file
+RUN curl -O https://raw.githubusercontent.com/ECCC-CCCS/geomet-climate/master/geomet-climate.yml --create-dirs --output /opt/geomet-climate
 
 # get latest schemas.opengis.net
 RUN mkdir schemas.opengis.net && \


### PR DESCRIPTION
This PR replaces the install of `geomet-climate` in the nightly Docker container with simply doing a `curl` of the `geomet-climate.yml` file to the container's `/opt/geomet-climate` path, matching the default env of `GEOMET_CLIMATE_CONFIG = '/opt/geomet-climate/geomet-climate.yml'`

Tested on nightly build with a sample raster drill request to `/msc-pygeoapi/processes/raster-drill/execution`:

```json
{"inputs":{"layer":"CANGRD.ANO.TM_ANNUAL","y":52.591,"x":-115.629,"format":"CSV"},"response":"raw"}
```