### PR TITLE
Update nightly docker build configurations for geomet-dev-21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,9 @@ WORKDIR $BASEDIR
 RUN sed -i 's/http:\/\/archive.ubuntu.com\/ubuntu\//mirror:\/\/mirrors.ubuntu.com\/mirrors.txt/g' /etc/apt/sources.list
 RUN apt-get update && \
     apt-get install -y software-properties-common  && \
-    apt-get install -y python3 python3-pip git curl unzip python3-gdal 
+    add-apt-repository ppa:gcpp-kalxas/wmo && \
+    add-apt-repository ppa:ubuntugis/ppa && apt update && \
+    apt-get install -y python3 python3-setuptools python3-pip git curl unzip python3-click python3-fiona python3-gdal python3-lxml python3-parse python3-pyproj python3-rasterio python3-requests python3-slugify python3-sqlalchemy python3-unicodecsv python3-xarray python3-yaml
 
 # install pygeoapi
 RUN git clone $PYGEOAPI_GITREPO && \

--- a/deploy/default/msc-pygeoapi-config.yml
+++ b/deploy/default/msc-pygeoapi-config.yml
@@ -1068,7 +1068,6 @@ resources:
                   - wind_speed__vitesse_vent
                   - wind_speed_units__vitesse_vent_unites
 
-
     ahccd-trends:
         type: collection
         title:
@@ -1590,7 +1589,6 @@ resources:
         keywords:
             en: [MetNote, Contextual information, Forecaster comment, Impact]
             fr: [MetNote, Renseignements contextuels, Commentaire du prévisionniste, Impact]
-
         crs:
             - CRS84
         links:

--- a/deploy/nightly/deploy-nightly-docker.sh
+++ b/deploy/nightly/deploy-nightly-docker.sh
@@ -60,8 +60,8 @@ echo "Cloning Git repository"
 git clone $MSC_PYGEOAPI_GITREPO . -b master --depth=1
 
 echo "Stopping/building/starting Docker setup"
-docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml down
 docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml build --no-cache
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml down
 docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up -d
 
 cat > msc-pygeoapi-nightly.conf <<EOF


### PR DESCRIPTION
This PR updates the nightly build for dev-21:
- commented out various collections temporarily
  - [x] undo commented out collections when ready on dev-21
- docker build order optimization
- nightly build sh to use "docker-dev-21" branch for testing dev-21
  - [x] switch back to "master" branch when ready