### PR TITLE
updated needed for the RDPA CovJSON output

### DIFF
--- a/msc_pygeoapi/provider/rdpa_rasterio.py
+++ b/msc_pygeoapi/provider/rdpa_rasterio.py
@@ -505,7 +505,7 @@ class RDPAProvider(BaseProvider):
                     'coordinates': ['x', 'y'],
                     'system': {
                         'type': self._coverage_properties['crs_type'],
-                        'id': self._coverage_properties['bbox_crs']
+                        'id': 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
                     }
                 }]
             },


### PR DESCRIPTION
updated needed for the RDPA CovJSON output, the newer version on dev-21 were setting the CRS to None instead of 4326.

This is to have a valid CovJSON output.