### PR TITLE
adding the msc datasets footprints as a collection

### DIFF
--- a/deploy/default/msc-pygeoapi-config.yml
+++ b/deploy/default/msc-pygeoapi-config.yml
@@ -3361,6 +3361,41 @@ resources:
                   name: GRIB
                   mimetype: application/x-grib2
 
+    datasets-footprints:
+        type: collection
+        title:
+            en: MSC Datasets Footprints
+            fr: Empreintes des jeux de données du SMC
+        description:
+            en: MSC datasets footprints inventory
+            fr: Inventaire des empreintes des jeux de données du SMC
+        keywords:
+            en: [discovery, weather, open data, climate]
+            fr: [découverte, météo, données ouvertes, climat]
+        crs:
+            - CRS84
+        links:
+            - type: text/html
+              rel: canonical
+              title:
+                en: Meteorological Service of Canada open data
+                fr: Données ouvertes du Service météorologique du Canada
+              href:
+                en: https://eccc-msc.github.io/open-data/msc-data/readme_en
+                fr: https://eccc-msc.github.io/open-data/msc-data/readme_fr
+              hreflang:
+                en: en-CA
+                fr: fr-CA
+        extents:
+            spatial:
+                bbox: [-180, -90, 180, 90]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+        providers:
+            - type: feature
+              name: Elasticsearch
+              data: ${MSC_PYGEOAPI_ES_URL}/msc_dataset_footprints
+              id_field: id
+
     # discovery-metadata:
     #     type: collection
     #     title:


### PR DESCRIPTION
adding the msc datasets footprints as a collection based on the MCF, see issue 667

I also improved the error handling in the footprint loader.

Note that this collection is to be updated only when needed, and does not need to be tied to a AQMP feed.

@Dukestep @alexandreleroux @kngai 