### PR TITLE
disable emails sent by cron

### DIFF
--- a/debian/msc-pygeoapi.cron.d
+++ b/debian/msc-pygeoapi.cron.d
@@ -1,3 +1,4 @@
+MAILTO=""
 # =================================================================
 #
 # Author: Tom Kralidis <tom.kralidis@canada.ca>


### PR DESCRIPTION
This MR disables emails being sent via cron jobs by adding setting `MAILTO=""`.