### PR TITLE
fix metnotes subtopic in its sarra config

### DIFF
--- a/deploy/default/sarracenia/metnotes.conf
+++ b/deploy/default/sarracenia/metnotes.conf
@@ -1,6 +1,6 @@
 broker amqps://anonymous:anonymous@hpfx.collab.science.gc.ca
 queue_name q_${BROKER_USER}.${PROGRAM}.${CONFIG}.${HOSTNAME}
-subtopic *.WXO-DD.metnotes.aqhi.#
+subtopic *.WXO-DD.metnotes.#
 mirror True
 discard on
 report_back False


### PR DESCRIPTION
This MR fixes a typo in the MetNotes sarra configuration which included a typo in its subtopic value.

This will require us to cut a new tag if we want to include MetNotes in the upcoming release.

CC @RousseauLambertLP