### PR TITLE
ensure metnotes item ID equates to the ES id

### DIFF
--- a/deploy/default/msc-pygeoapi-config.yml
+++ b/deploy/default/msc-pygeoapi-config.yml
@@ -1620,6 +1620,7 @@ resources:
               time_field: publication_datetime
               properties:
                   - id
+                  - metnote_id
                   - aors
                   - type_id
                   - publication_version

--- a/msc_pygeoapi/loader/metnotes.py
+++ b/msc_pygeoapi/loader/metnotes.py
@@ -213,7 +213,8 @@ class MetNotesRealtimeLoader(BaseLoader):
                     feature['properties']['publication_version']
                 )
 
-                feature['properties']['id'] = feature['id']
+                feature['properties']['metnote_id'] = feature['id']
+                feature['id'] = feature['properties']['id'] = id_
                 feature['properties']['metnote_status'] = 'inactive'
                 feature['properties']['filename'] = self.filename
 


### PR DESCRIPTION
This PR fixes an issue with the MetNotes config and loader where the collection item ID did not match up with the ES document ID as defined in the loader.

This ensures we are able to keep a history of changes made to a MetNote (instead of overwriting an existing MetNote) while also ensuring a feature's `/items/<id>` path correctly resolves to the individual item in question.

@tomkralidis, this will require a cutting a new release.

CC @RousseauLambertLP  