### PR TITLE
BUGFIX: new click version replaces _ by -

### DIFF
--- a/debian/msc-pygeoapi.cron.d
+++ b/debian/msc-pygeoapi.cron.d
@@ -29,25 +29,25 @@ MAILTO=""
 # =================================================================
 
 # every day at 0300h, clean bulletin records from ES
-0 3 * * * geoadm msc-pygeoapi data bulletins_realtime clean_indexes --days 140 --yes
+0 3 * * * geoadm msc-pygeoapi data bulletins-realtime clean-indexes --days 140 --yes
 
 # every day at 0400h, clean hydrometric realtime data older than 30 days
-0 4 * * * geoadm msc-pygeoapi data hydrometric_realtime clean_indexes --days 30 --yes
+0 4 * * * geoadm msc-pygeoapi data hydrometric-realtime clean-indexes --days 30 --yes
 
 # every hour on the 04, cache hydrometric stations
-4 * * * * geoadm msc-pygeoapi data hydrometric_realtime cache-stations
+4 * * * * geoadm msc-pygeoapi data hydrometric-realtime cache-stations
 
 # every day at 0500h, clean swob realtime data older than 30 days
-0 5 * * * geoadm msc-pygeoapi data swob_realtime clean_indexes --days 30 --yes
+0 5 * * * geoadm msc-pygeoapi data swob-realtime clean-indexes --days 30 --yes
 
 # every day at 0600h, clean aqhi realtime data older than 3 days
-0 6 * * * geoadm msc-pygeoapi data aqhi_realtime clean_indexes --dataset all --days 3 --yes
+0 6 * * * geoadm msc-pygeoapi data aqhi-realtime clean-indexes --dataset all --days 3 --yes
 
 # every day at 0700h, clean metnotes data older than 7 days
-0 7 * * * geoadm msc-pygeoapi data metnotes clean_indexes --days 7 --yes
+0 7 * * * geoadm msc-pygeoapi data metnotes clean-indexes --days 7 --yes
 
 # every day at 0800h, clean ltce data older than 3 days
-0 8 * * * geoadm msc-pygeoapi data ltce clean_indexes --days 3 --yes
+0 8 * * * geoadm msc-pygeoapi data ltce clean-indexes --days 3 --yes
 
 # every day at 0300h, clean out empty MetPX directories
 0 3 * * * geoadm /usr/bin/find $MSC_PYGEOAPI_CACHEDIR -type d -empty -delete > /dev/null 2>&1


### PR DESCRIPTION
new click version replaces _ by -, see  https://click.palletsprojects.com/en/7.x/api/ (`The name of the command defaults to the name of the function with underscores replaced by dashes`) while previsou version didn't haev this behavior (https://click.palletsprojects.com/en/6.x/api/).

This is a bugfix and should be backported in the 0.11 branch.