### PR TITLE
[BUGFIX] update metnotes ES mapping

### DIFF
--- a/msc_pygeoapi/loader/metnotes.py
+++ b/msc_pygeoapi/loader/metnotes.py
@@ -74,6 +74,14 @@ MAPPINGS = {
                         }
                     }
                 },
+                'metnote_id': {
+                    'type': 'text',
+                    'fields': {
+                        'raw': {
+                            'type': 'keyword'
+                        }
+                    }
+                },
                 'aors': {
                     'type': 'keyword',
                     'index': 'true'


### PR DESCRIPTION
This PR updates the MetNotes ES mapping to ensure the new `metnote_id` property is present.

Please backport to 0.11 branch.