### PR TITLE
BUGFIX: ensure ltce indice names can be be parsed with python3-parse 1.6.6

### DIFF
--- a/msc_pygeoapi/loader/ltce.py
+++ b/msc_pygeoapi/loader/ltce.py
@@ -53,7 +53,7 @@ LOGGER.setLevel(getattr(logging, MSC_PYGEOAPI_LOGGING_LOGLEVEL))
 DAYS_TO_KEEP = 7
 
 INDEX_BASENAME = 'ltce_{}.'
-INDEX_PATTERN = '{index_name}.{year:d}-{month:d}-{day:d}.{hour:2d}{minute:2d}{second:2d}'  # noqa
+INDEX_PATTERN = '{index_name}.{year:d}-{month:d}-{day:d}.{hour:d}-{minute:d}-{second:d}'  # noqa
 
 SETTINGS = {
     'order': 0,
@@ -362,7 +362,7 @@ class LtceLoader(BaseLoader):
         BaseLoader.__init__(self)
         self.conn = ElasticsearchConnector(conn_config)
         self.db_conn = None
-        self.date = datetime.utcnow().strftime('%Y-%m-%d.%H%M%S')
+        self.date = datetime.utcnow().strftime('%Y-%m-%d.%H-%M-%S')
 
         # setup DB connection
         if db_string is not None:


### PR DESCRIPTION
This PR ensures that the index pattern defined for the LTCE-related indices can be properly parsed by the `parse` module on our focal environments.

Support for precision and width specifiers when parsing numbers and strings was only added in parse `1.9.0`. The version installed via the default Ubuntu focal repository is `1.6.6`.

Please backport to 0.11 branch.

CC @RousseauLambertLP 