### PR TITLE
BUGFIX: update data_encoding for cansips and rdpa causing errors with no data

### DIFF
--- a/msc_pygeoapi/provider/cansips_rasterio.py
+++ b/msc_pygeoapi/provider/cansips_rasterio.py
@@ -443,7 +443,6 @@ class CanSIPSProvider(BaseProvider):
             else:
                 LOGGER.debug('Serializing data in memory')
                 out_meta.update(count=len(args['indexes']))
-                out_meta.update(DATA_ENCODING='IEEE_FLOATING_POINT')
                 with MemoryFile() as memfile:
                     with memfile.open(**out_meta, nbits=nbits) as dest:
                         dest.write(out_image)

--- a/msc_pygeoapi/provider/rdpa_rasterio.py
+++ b/msc_pygeoapi/provider/rdpa_rasterio.py
@@ -427,7 +427,6 @@ class RDPAProvider(BaseProvider):
                     out_meta['bands'] = [1]
                     return self.gen_covjson(out_meta, out_image)
             else:
-                out_meta.update(DATA_ENCODING='IEEE_FLOATING_POINT')
                 if date_file_list:
                     out_meta.update(count=len(date_file_list))
 


### PR DESCRIPTION
update data_encoding for cansips and rdpa causing errors with no data

see issue msc-geomet 696

The data encoding used to remove the no data values from the OACov output. 

This is a BUGFIX and needs to be backported in the 0.11 branch.

cc @Dukestep 