### PR TITLE
remove LTCE indexes cleanup from cron

### DIFF
--- a/debian/msc-pygeoapi.cron.d
+++ b/debian/msc-pygeoapi.cron.d
@@ -46,8 +46,5 @@ MAILTO=""
 # every day at 0700h, clean metnotes data older than 7 days
 0 7 * * * geoadm . /local/home/geoadm/.profile && msc-pygeoapi data metnotes clean-indexes --days 7 --yes
 
-# every day at 0800h, clean ltce data older than 3 days
-0 8 * * * geoadm . /local/home/geoadm/.profile && msc-pygeoapi data ltce clean-indexes --days 3 --yes
-
 # every day at 0300h, clean out empty MetPX directories
 0 3 * * * geoadm . /local/home/geoadm/.profile && /usr/bin/find $MSC_PYGEOAPI_CACHEDIR -type d -empty -delete > /dev/null 2>&1


### PR DESCRIPTION
This PR removes the LTCE cleanup job from the cron since this does not need to be managed via the installed cron.