### PR TITLE
fix f-string missing closing curly bracket

### DIFF
--- a/msc_pygeoapi/provider/cangrd_rasterio.py
+++ b/msc_pygeoapi/provider/cangrd_rasterio.py
@@ -611,7 +611,7 @@ class CanGRDProvider(BaseProvider):
 
         if self._data.crs is not None:
             if self._data.crs.is_projected:
-                bbox_crs = f'http://www.opengis.net/def/crs/OGC/1.3/{self._data.crs.to_epsg()'  # noqa
+                bbox_crs = f'http://www.opengis.net/def/crs/OGC/1.3/{self._data.crs.to_epsg()}'  # noqa
                 properties['bbox_crs'] = bbox_crs
 
                 properties['x_axis_label'] = 'x'


### PR DESCRIPTION
This MR fixes a missing closing bracket in a f-string literal in the CanGRD provider.