### PR TITLE
Fix to string wrapper causing JS syntax error

### DIFF
--- a/theme/templates/stac/item.html
+++ b/theme/templates/stac/item.html
@@ -111,7 +111,7 @@
       map.addLayer(bbox_layer);
       map.fitBounds(bbox_layer.getBounds(), {maxZoom: 5});
     } else {
-      const warnAlert = '<div class="alert alert-warning mrgn-tp-md">{% trans %}Map extent preview not available{% endtrans %}</div>';
+      const warnAlert = `<div class="alert alert-warning mrgn-tp-md">{% trans %}Map extent preview not available{% endtrans %}</div>`;
       document.getElementById('items-map').insertAdjacentHTML('afterend', warnAlert);
     }
     </script>


### PR DESCRIPTION
This PR fixes the string wrapper, as the text itself uses both single and double quotes when `lang=fr`