### PR TITLE
use f-strings in place of .join() method when var type uncertain

### DIFF
--- a/msc_pygeoapi/loader/ahccd.py
+++ b/msc_pygeoapi/loader/ahccd.py
@@ -494,22 +494,21 @@ class AhccdLoader(BaseLoader):
                 record['properties']['identifier__identifiant'] = stn_id
             elif index == 'monthly':
                 index_name = 'ahccd_monthly'
-                record['properties']['date'] = '-'.join([
-                    record['properties']['identifier__identifiant'].split('.')[
-                        1
-                    ],
-                    record['properties']['identifier__identifiant'].split('.')[
-                        2
-                    ],
-                ])
+                date_parts = record['properties'][
+                    'identifier__identifiant'
+                ].split('.')
+                record['properties'][
+                    'date'
+                ] = f"{date_parts[1]}-{date_parts[2]}"
                 del record['properties']['year__annee']
             elif index == 'trends':
                 index_name = 'ahccd_trends'
-                identifier = '.'.join([
+                station_id, period, measurement_type = (
                     record['properties']['station_id__id_station'],
                     record['properties']['period__periode'],
                     record['properties']['measurement_type__type_mesure']
-                ])
+                )
+                identifier = f'{station_id}.{period}.{measurement_type}'
                 record['properties']['identifier__identifiant'] = identifier
 
             action = {

--- a/msc_pygeoapi/loader/climate_archive.py
+++ b/msc_pygeoapi/loader/climate_archive.py
@@ -697,11 +697,12 @@ class ClimateArchiveLoader(BaseLoader):
                         if insert_dict[key] is not None
                         else insert_dict[key]
                     )
-            insert_dict['ID'] = '.'.join([
+            stn_id, normal_id, month = (
                 insert_dict['STN_ID'],
                 insert_dict['NORMAL_ID'],
                 insert_dict['MONTH']
-            ])
+            )
+            insert_dict['ID'] = f'{stn_id}.{normal_id}.{month}'
             if insert_dict['STN_ID'] in stn_dict:
                 coords = stn_dict[insert_dict['STN_ID']]['coordinates']
                 insert_dict['STATION_NAME'] = stn_dict[insert_dict['STN_ID']][
@@ -794,12 +795,12 @@ class ClimateArchiveLoader(BaseLoader):
                 if insert_dict['LAST_UPDATED'] is not None
                 else insert_dict['LAST_UPDATED']
             )
-
-            insert_dict['ID'] = '.'.join([
+            stn_id, local_year, local_month = (
                 insert_dict['STN_ID'],
                 insert_dict['LOCAL_YEAR'],
                 insert_dict['LOCAL_MONTH']
-            ])
+            )
+            insert_dict['ID'] = f'{stn_id}.{local_year}.{local_month}'
             if insert_dict['STN_ID'] in stn_dict:
                 coords = stn_dict[insert_dict['STN_ID']]['coordinates']
                 insert_dict['PROVINCE_CODE'] = stn_dict[insert_dict['STN_ID']][
@@ -877,12 +878,13 @@ class ClimateArchiveLoader(BaseLoader):
                     else insert_dict['LOCAL_DATE']
                 )
 
-                insert_dict['ID'] = '.'.join([
+                climate_identifier, local_year, local_month, local_day = (
                     insert_dict['CLIMATE_IDENTIFIER'],
                     insert_dict['LOCAL_YEAR'],
                     insert_dict['LOCAL_MONTH'],
                     insert_dict['LOCAL_DAY']
-                ])
+                )
+                insert_dict['ID'] = f'{climate_identifier}.{local_year}.{local_month}.{local_day}'  # noqa
                 if insert_dict['STN_ID'] in stn_dict:
                     coords = stn_dict[insert_dict['STN_ID']]['coordinates']
                     insert_dict['PROVINCE_CODE'] = stn_dict[
@@ -962,14 +964,14 @@ class ClimateArchiveLoader(BaseLoader):
                     if insert_dict['LOCAL_DATE'] is not None
                     else insert_dict['LOCAL_DATE']
                 )
-
-                insert_dict['ID'] = '.'.join([
+                climate_identifier, local_year, local_month, local_day, local_hour = (  # noqa
                     insert_dict['CLIMATE_IDENTIFIER'],
                     insert_dict['LOCAL_YEAR'],
                     insert_dict['LOCAL_MONTH'],
                     insert_dict['LOCAL_DAY'],
                     insert_dict['LOCAL_HOUR']
-                ])
+                )
+                insert_dict['ID'] = f'{climate_identifier}.{local_year}.{local_month}.{local_day}.{local_hour}'  # noqa
                 if insert_dict['STN_ID'] in stn_dict:
                     coords = stn_dict[insert_dict['STN_ID']]['coordinates']
                     insert_dict['PROVINCE_CODE'] = stn_dict[

--- a/msc_pygeoapi/loader/hydat.py
+++ b/msc_pygeoapi/loader/hydat.py
@@ -476,9 +476,7 @@ class HydatLoader(BaseLoader):
                     word_out: '',
                     'IDENTIFIER': '',
                 }
-                date_ = '-'.join([
-                    str(row[1]), self.zero_pad(row[2]), self.zero_pad(i)
-                ])
+                date_ = f'{row[1]}-{self.zero_pad(row[2])}-{self.zero_pad(i)}'
                 insert_dict['DATE'] = date_
                 insert_dict['IDENTIFIER'] = f'{row[0]}.{date_}'
                 value = row[keys.index(word_in.upper() + str(i))]
@@ -889,18 +887,14 @@ class HydatLoader(BaseLoader):
                     f'Could not find min date for station {station_number}'
                 )
             else:
-                min_date = '-'.join([
-                    year, self.zero_pad(min_month), self.zero_pad(min_day)
-                ])
+                min_date = f'{year}-{self.zero_pad(min_month)}-{self.zero_pad(min_day)}' # noqa
             if max_month is None or max_day is None:
                 max_date = None
                 LOGGER.warning(
                     f'Could not find max date for station {station_number}'
                 )
             else:
-                max_date = '-'.join([
-                    year, self.zero_pad(max_month), self.zero_pad(max_day)
-                ])
+                max_date = f'{year}-{self.zero_pad(max_month)}-{self.zero_pad(max_day)}' # noqa
             symbol_keys = symbol_table.columns.keys()
             if min_symbol is not None and min_symbol.strip():
                 args = {'SYMBOL_ID': min_symbol}
@@ -1036,11 +1030,9 @@ class HydatLoader(BaseLoader):
                     f'Could not find date for station {station_number}'
                 )
             elif hour is None or minute is None:
-                date_ = '-'.join([
-                    year, self.zero_pad(month), self.zero_pad(day)
-                ])
+                date_ = f'{year}-{self.zero_pad(month)}-{self.zero_pad(day)}'
             else:
-                ymd = '-'.join([year, self.zero_pad(month), self.zero_pad(day)])  # noqa
+                ymd = f'{year}-{self.zero_pad(month)}-{self.zero_pad(day)}'
                 hm = ':'.join([self.zero_pad(hour), self.zero_pad(minute)])
                 date_ = f'{ymd}T{hm}'
 

--- a/msc_pygeoapi/loader/ltce.py
+++ b/msc_pygeoapi/loader/ltce.py
@@ -554,14 +554,15 @@ class LtceLoader(BaseLoader):
                         else insert_dict[key]
                     )
 
+            virtual_climate_id, element_name, climate_identifier, start, end = (  # noqa
+                insert_dict['VIRTUAL_CLIMATE_ID'],
+                insert_dict['ELEMENT_NAME_E'],
+                insert_dict['CLIMATE_IDENTIFIER'],
+                insert_dict['START_DATE'],
+                insert_dict['END_DATE']
+            )
             es_id = slugify(
-                '-'.join([
-                    insert_dict['VIRTUAL_CLIMATE_ID'],
-                    insert_dict["ELEMENT_NAME_E"],
-                    insert_dict["CLIMATE_IDENTIFIER"],
-                    insert_dict["START_DATE"],
-                    insert_dict["END_DATE"]
-                ])
+                f'{virtual_climate_id}-{element_name}-{climate_identifier}-{start}-{end}'  # noqa
             )
 
             coords = [
@@ -679,13 +680,12 @@ class LtceLoader(BaseLoader):
                         else insert_dict[key]
                     )
 
-            virtual_climate_id = insert_dict['VIRTUAL_CLIMATE_ID']
-            es_id = '-'.join([
+            virtual_climate_id, local_month, local_day = (
                 insert_dict['VIRTUAL_CLIMATE_ID'],
                 insert_dict['LOCAL_MONTH'],
                 insert_dict['LOCAL_DAY']
-            ])
-
+            )
+            es_id = f'{virtual_climate_id}-{local_month}-{local_day}'
             # check if we have station IDs record begin and end. If not
             # retrieve the information and store in stations_dict
             if virtual_climate_id not in stations_dict:
@@ -827,13 +827,12 @@ class LtceLoader(BaseLoader):
                         else insert_dict[key]
                     )
 
-            virtual_climate_id = insert_dict['VIRTUAL_CLIMATE_ID']
-            es_id = '-'.join([
+            virtual_climate_id, local_month, local_day = (
                 insert_dict['VIRTUAL_CLIMATE_ID'],
-                insert_dict["LOCAL_MONTH"],
-                insert_dict["LOCAL_DAY"]
-            ])
-
+                insert_dict['LOCAL_MONTH'],
+                insert_dict['LOCAL_DAY']
+            )
+            es_id = f'{virtual_climate_id}-{local_month}-{local_day}'
             # check if we have station IDs record begin and end if not retrieve
             if virtual_climate_id not in stations_dict:
                 stations_dict[virtual_climate_id] = self.get_stations_info(
@@ -940,12 +939,12 @@ class LtceLoader(BaseLoader):
                         else insert_dict[key]
                     )
 
-            virtual_climate_id = insert_dict['VIRTUAL_CLIMATE_ID']
-            es_id = '-'.join([
+            virtual_climate_id, local_month, local_day = (
                 insert_dict['VIRTUAL_CLIMATE_ID'],
-                insert_dict["LOCAL_MONTH"],
-                insert_dict["LOCAL_DAY"]
-            ])
+                insert_dict['LOCAL_MONTH'],
+                insert_dict['LOCAL_DAY']
+            )
+            es_id = f'{virtual_climate_id}-{local_month}-{local_day}'
 
             # check if we have station IDs record begin and end if not retrieve
             if virtual_climate_id not in stations_dict:


### PR DESCRIPTION
This PR reverts some changes made in #305 where certain loaders were modified to use the string `join()` method to create IDs or document properties in various loaders.

In some cases, the parameters passed to the `join()` method were not strings and this was causing loaders to fail and raise a `TypeError`. Switching these back to f-strings allows us format these non-string values as strings by calling the object's `__format__` dunder method.

