### PR TITLE
update support for cftime in climate NetCDF

### DIFF
--- a/msc_pygeoapi/provider/climate_xarray.py
+++ b/msc_pygeoapi/provider/climate_xarray.py
@@ -29,6 +29,8 @@
 #
 # =================================================================
 
+import cftime
+from datetime import datetime
 import logging
 import tempfile
 
@@ -307,6 +309,12 @@ class ClimateProvider(XarrayProvider):
         """
 
         try:
+            if isinstance(datetime_, cftime._cftime.DatetimeNoLeap):
+                cftime_str = datetime_.strftime('%Y-%m-%d %H:%M:%S')
+                python_datetime = datetime.strptime(cftime_str,
+                                                    '%Y-%m-%d %H:%M:%S')
+                datetime_ = np.datetime64(python_datetime)
+
             if any(month in self.data for month in self.monthly_data):
                 month = datetime_.astype('datetime64[M]').astype(int) % 12 + 1
                 year = datetime_.astype('datetime64[Y]').astype(int) + 1970


### PR DESCRIPTION
Since our migration to the new focal servers, we add issues with update support for cftime in climate NetCDF.

This is now fixed.

Nightly/Dev/Stage/Ops (https://[api.weather.gc.ca/collections/climate:cmip5:projected:annual:absolute/coverage/domainset?f=json](https://api.weather.gc.ca/collections/climate:cmip5:projected:annual:absolute/coverage/domainset?f=json)): 
```json
            {
                "type": "RegularAxis",
                "axisLabel": "time",
                "lowerBound": null,
                "upperBound": null,
                "uomLabel": "year",
                "resolution": 1
            },
```

My build with the fix:
```json
            {
                "type": "RegularAxis",
                "axisLabel": "time",
                "lowerBound": "2006",
                "upperBound": "2100",
                "uomLabel": "year",
                "resolution": 1
            },
```