### PR TITLE
fix typo in OBJECTID property name

### DIFF
--- a/msc_pygeoapi/loader/forecast_polygons.py
+++ b/msc_pygeoapi/loader/forecast_polygons.py
@@ -51,7 +51,7 @@ LOGGER = logging.getLogger(__name__)
 INDEX_NAME = 'forecast_polygons_{}_{}'
 
 FILE_PROPERTIES = {
-    'OBJECT_ID': {
+    'OBJECTID': {
         'type': 'integer',
     },
     'CLC': {


### PR DESCRIPTION
This PR removes the additional underscore in the `OBJECTID` property name in the defintion of the  index mapping for forecast regions, as it is written in the source data.