### PR TITLE
remove warnings for Xarray based backends

### DIFF
--- a/msc_pygeoapi/provider/candcsu6_xarray.py
+++ b/msc_pygeoapi/provider/candcsu6_xarray.py
@@ -231,8 +231,8 @@ class CanDCSU6Provider(XarrayProvider):
             'crs_type': 'GeographicCRS',
             'x_axis_label': self.x_field,
             'y_axis_label': self.y_field,
-            'width': self._data.dims[self.x_field],
-            'height': self._data.dims[self.y_field],
+            'width': self._data.sizes[self.x_field],
+            'height': self._data.sizes[self.y_field],
             'bbox_units': 'degrees',
             'resx': np.abs(self._data.coords[self.x_field].values[1]
                            - self._data.coords[self.x_field].values[0]),
@@ -266,7 +266,7 @@ class CanDCSU6Provider(XarrayProvider):
                     self._data.coords[self.time_field].values[-1]
                 )
             ]
-            properties['time'] = self._data.dims[self.time_field]
+            properties['time'] = self._data.sizes[self.time_field]
 
         properties['fields'] = [name for name in self._data.variables
                                 if len(self._data.variables[name].shape) >= 3]
@@ -490,8 +490,8 @@ class CanDCSU6Provider(XarrayProvider):
             ],
             'time': [None, None],
             "driver": "xarray",
-            "height": data.dims[self.y_field],
-            "width": data.dims[self.x_field],
+            "height": data.sizes[self.y_field],
+            "width": data.sizes[self.x_field],
             "time_steps": 1,
             "variables": {var_name: var.attrs
                           for var_name, var in data.variables.items()}
@@ -504,7 +504,7 @@ class CanDCSU6Provider(XarrayProvider):
                 self._to_datetime_string(
                     data.coords[self.time_field].values[-1])
             ]
-            out_meta['time_steps'] = data.dims[self.time_field]
+            out_meta['time_steps'] = data.sizes[self.time_field]
 
         self.filename = self.data.split('/')[-1].replace(
             '*', '-'.join(properties))

--- a/msc_pygeoapi/provider/climate_xarray.py
+++ b/msc_pygeoapi/provider/climate_xarray.py
@@ -235,8 +235,8 @@ class ClimateProvider(XarrayProvider):
             'crs_type': 'GeographicCRS',
             'x_axis_label': self.x_field,
             'y_axis_label': self.y_field,
-            'width': self._data.dims[self.x_field],
-            'height': self._data.dims[self.y_field],
+            'width': self._data.sizes[self.x_field],
+            'height': self._data.sizes[self.y_field],
             'bbox_units': 'degrees',
             'resx': np.abs(self._data.coords[self.x_field].values[1]
                            - self._data.coords[self.x_field].values[0]),
@@ -270,7 +270,7 @@ class ClimateProvider(XarrayProvider):
                     self._data.coords[self.time_field].values[-1]
                 )
             ]
-            properties['time'] = self._data.dims[self.time_field]
+            properties['time'] = self._data.sizes[self.time_field]
 
         properties['fields'] = [name for name in self._data.variables
                                 if len(self._data.variables[name].shape) >= 3]
@@ -531,8 +531,8 @@ class ClimateProvider(XarrayProvider):
             ],
             'time': [None, None],
             "driver": "xarray",
-            "height": data.dims[self.y_field],
-            "width": data.dims[self.x_field],
+            "height": data.sizes[self.y_field],
+            "width": data.sizes[self.x_field],
             "time_steps": 1,
             "variables": {var_name: var.attrs
                           for var_name, var in data.variables.items()}
@@ -545,7 +545,7 @@ class ClimateProvider(XarrayProvider):
                 self._to_datetime_string(
                     data.coords[self.time_field].values[-1])
             ]
-            out_meta['time_steps'] = data.dims[self.time_field]
+            out_meta['time_steps'] = data.sizes[self.time_field]
 
         self.filename = self.data.split('/')[-1].replace(
             '*', '-'.join(properties))

--- a/msc_pygeoapi/provider/spei_xarray.py
+++ b/msc_pygeoapi/provider/spei_xarray.py
@@ -214,9 +214,9 @@ class SPEIProvider(ClimateProvider):
                     data.coords[self.time_field].values[-1])
             ],
             "driver": "xarray",
-            "height": data.dims[self.y_field],
-            "width": data.dims[self.x_field],
-            "time_steps": data.dims[self.time_field],
+            "height": data.sizes[self.y_field],
+            "width": data.sizes[self.x_field],
+            "time_steps": data.sizes[self.time_field],
             "variables": {var_name: var.attrs
                           for var_name, var in data.variables.items()}
         }


### PR DESCRIPTION
This PR removes FutureWarnings on Xarray-based backends:

```
 /home/runner/work/pygeoapi/pygeoapi/pygeoapi/provider/xarray_.py:389: FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.
```

Related implementation of https://github.com/geopython/pygeoapi/pull/1623