### PR TITLE
Implement leaflet.markercluster for items map

### DIFF
--- a/theme/templates/_base.html
+++ b/theme/templates/_base.html
@@ -29,7 +29,10 @@
     <script type="importmap">
       {
         "imports": {
-          "vue": "https://cdnjs.cloudflare.com/ajax/libs/vue/3.0.7/vue.esm-browser.prod.js"
+          "vue": "https://cdnjs.cloudflare.com/ajax/libs/vue/3.0.7/vue.esm-browser.prod.js",
+          "leaflet": "https://unpkg.com/leaflet@1.7.1/dist/leaflet-src.esm.js",
+          "leaflet-non-esm": "https://unpkg.com/leaflet/dist/leaflet.js",
+          "leaflet.markercluster": "https://unpkg.com/leaflet.markercluster/dist/leaflet.markercluster-src.js"
         }
       }
     </script>

--- a/theme/templates/collections/items/index.html
+++ b/theme/templates/collections/items/index.html
@@ -24,6 +24,8 @@
 {% endblock %}
 {% block extrahead %}
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"/>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster/dist/MarkerCluster.css"/>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster/dist/MarkerCluster.Default.css"/>
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
Similar to https://github.com/geopython/pygeoapi/pull/1025, this PR implements the use of Leaflet markerClusterGroup plugin only for the collection/items/index.html page.

JS code changes were made to make this work:
- Removed use of leaflet-esm in order to work with the non-esm supported L.markerClusterGroup
- Loading leaflet-non-esm and leaflet.markercluster via ESM import map for ease of view
- Add logic to determine if GeoJSON is point geometry or not for markerCluster handling