### PR TITLE
fix issues with CityPage Weather current conditions loader

### DIFF
--- a/deploy/default/msc-pygeoapi-config.yml
+++ b/deploy/default/msc-pygeoapi-config.yml
@@ -719,30 +719,6 @@ resources:
               data: ${MSC_PYGEOAPI_ES_URL}/current_conditions
               id_field: identifier
               time_field: timestamp
-              properties:
-                  - identifier
-                  - name
-                  - station_en
-                  - station_fr
-                  - icon
-                  - cond_en
-                  - cond_fr
-                  - temp
-                  - dewpoint
-                  - pres_en
-                  - pres_fr
-                  - prestnd_en
-                  - prestnd_fr
-                  - rel_hum
-                  - speed
-                  - direction_en
-                  - direction_fr
-                  - bearing
-                  - timestamp
-                  - url_en
-                  - url_fr
-                  - national
-                  - nom
 
     climate-daily:
         type: collection

--- a/msc_pygeoapi/loader/citypageweather_realtime.py
+++ b/msc_pygeoapi/loader/citypageweather_realtime.py
@@ -184,7 +184,12 @@ SETTINGS = {
                         "type": "integer"
                     },
                     'speed': {
-                        "type": "integer"
+                        'type': 'text',
+                        'fields': {
+                            'raw': {
+                                'type': 'keyword'
+                            }
+                        }
                     },
                     'gust': {
                         "type": "integer"
@@ -305,9 +310,9 @@ class CitypageweatherRealtimeLoader(BaseLoader):
 
         try:
             if type_ == 'f':
-                variable = float(value) if value else 'null'
+                variable = float(value) if value else None
             elif type_ == 'i':
-                variable = int(value) if value else 'null'
+                variable = int(value) if value else None
         except ValueError:
             variable = value
 
@@ -484,7 +489,7 @@ class CitypageweatherRealtimeLoader(BaseLoader):
                     }
                 }
 
-            conditions['properties'] = {key:val for key, val in conditions['properties'].items() if val != 'null'} # noqa
+            conditions['properties'] = {key:val for key, val in conditions['properties'].items() if val is not None} # noqa
             return conditions
 
         else:


### PR DESCRIPTION
This PR fixes a few issues with the CityPage Weather current conditions loader.

1) Removes the properties fields, given that the fields list is not static. This was causing some issues when defined fields were missing from the feature's properties.

2) Ensure the `speed` field is mapped as a `text` field in the Elasticsearch mapping for the current_conditions index.

3) Use None instead of 'null' when a field is not available.