### PR TITLE
Fix debian/rules for GCWeb

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -23,10 +23,11 @@ MSC_PYGEOAPI_VERSION=$(shell dpkg-parsechangelog -SVersion)
 	&& rm -f ./SCHEMAS_OPENGIS_NET.zip
 	sed -i "s/MSC_PYGEOAPI_VERSION/$(MSC_PYGEOAPI_VERSION)/" theme/templates/_base.html
 
-	curl -L https://github.com/wet-boew/GCWeb/releases/download/v14.6.0/themes-dist-14.6.0-gcweb.1.zip -o ./themes-gcweb.zip
-	&& unzip -o ./themes-gcweb.zip "*/GCWeb/*" -d theme/static
-	&& unzip -o ./themes-gcweb.zip "*/wet-boew/*" -d theme/static
-	&& mv ./theme/static/themes-dist-14.6.0-gcweb ./theme/static/themes-gcweb
+	curl -L https://github.com/wet-boew/GCWeb/releases/download/v14.6.0/themes-dist-14.6.0-gcweb.1.zip -o ./themes-gcweb.zip \
+	&& unzip -o ./themes-gcweb.zip "*/GCWeb/*" -d theme/static \
+	&& unzip -o ./themes-gcweb.zip "*/wet-boew/*" -d theme/static \
+	&& rm -rf ./theme/static/themes-gcweb \
+	&& mv ./theme/static/themes-dist-14.6.0-gcweb ./theme/static/themes-gcweb \
 	&& rm -f ./themes-gcweb.zip
 
 override_dh_auto_test:


### PR DESCRIPTION
This PR fixes the debian/rules file related to obtain GCWeb theme files:
- Added missing `\` at EOL
- Added conditional check `rm -rf ./theme/static/themes-gcweb \` to remove existing folder if exists