### PR TITLE
ignore generic msc-mcf-template.yml when loading footprints

### DIFF
--- a/msc_pygeoapi/loader/nwp_dataset_footprints.py
+++ b/msc_pygeoapi/loader/nwp_dataset_footprints.py
@@ -51,7 +51,8 @@ LOGGER = logging.getLogger(__name__)
 
 MCFS_TO_IGNORE = [
     'msc_lightning.yml',
-    'msc_radar-*.yml'
+    'msc_radar-*.yml',
+    'msc-mcf-template.yml'
 ]
 
 # index settings


### PR DESCRIPTION
This PR ensures we ignore the MCF template (` msc-mcf-template.yml`) contained in the discovery-metadata repo when loading the entire `./mcf` directory when using  `msc-pygeoapi data nwp-dataset-footprints add -d $PATH_TO_MCF_DIR`.