### PR TITLE
add worklist_type parameter to EventBase.process_messages()

### DIFF
--- a/msc_pygeoapi/event/__init__.py
+++ b/msc_pygeoapi/event/__init__.py
@@ -40,7 +40,7 @@ LOGGER = logging.getLogger(__name__)
 
 class EventBase(FlowCB):
 
-    def process_messages(self, worklist) -> bool:
+    def process_messages(self, worklist, worklist_type: str) -> bool:
         """
         Process messages from the worklist
 
@@ -49,7 +49,7 @@ class EventBase(FlowCB):
         :returns: `bool`
         """
 
-        for msg in worklist.incoming:
+        for msg in getattr(worklist, worklist_type):
 
             try:
                 from msc_pygeoapi.handler.core import CoreHandler
@@ -77,7 +77,8 @@ class EventAfterWork(EventBase):
 
         :returns: `bool`
         """
-        return self.process_messages(worklist)
+
+        return self.process_messages(worklist, worklist_type='ok')
 
 
 class EventAfterAccept(EventBase):
@@ -90,4 +91,5 @@ class EventAfterAccept(EventBase):
 
         :returns: `bool`
         """
-        return self.process_messages(worklist)
+
+        return self.process_messages(worklist, worklist_type='incoming')


### PR DESCRIPTION
THis PR ensures the worklist type is passed with each event callback to ensure the appropriate worklist type is called for the appropriate routine (after_accept and after_work). When using the `after_work` routine and files are downloaded on disk, messages are found in `worklist.ok` as per the [sr3 callback documentation](https://metpx.github.io/sarracenia/Tutorials/2_CLI_with_flowcb_demo.html#Plugins-that-Process-a-file-after-it-is-Downloaded).

CC @adanb13