### PR TITLE
fix typo in callback env var formatting

### DIFF
--- a/deploy/default/sarracenia/metnotes.conf
+++ b/deploy/default/sarracenia/metnotes.conf
@@ -6,7 +6,7 @@ instances 2
 subtopic *.WXO-DD.metnotes.#
 
 directory ${MSC_PYGEOAPI_CACHEDIR}
-callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}}
+callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}
 mirror True
 discard True
 report False


### PR DESCRIPTION
Fixes a small typo in the environment variable reference for the callback directive in the MetNotes sr3 subscriber configuration.

@kngai can be backported into `0.13`.