### PR TITLE
[BUGFIX] apply sr3 discard directive workaround to ensure files removed

### DIFF
--- a/deploy/default/sarracenia/aqhi-realtime.conf
+++ b/deploy/default/sarracenia/aqhi-realtime.conf
@@ -7,6 +7,10 @@ subtopic *.WXO-DD.air_quality.aqhi.*.*.realtime.json.#
 
 mirror True
 discard True
+# workaround for discard directive bug in sr3
+# see https://github.com/MetPX/sarracenia/issues/1315
+delete_source off
+delete_destination on
 report False
 directory ${MSC_PYGEOAPI_CACHEDIR}
 logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}

--- a/deploy/default/sarracenia/cap-alerts.conf
+++ b/deploy/default/sarracenia/cap-alerts.conf
@@ -9,4 +9,8 @@ callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}
 directory /data/geomet/feeds/hpfx
 mirror True
 discard True
+# workaround for discard directive bug in sr3
+# see https://github.com/MetPX/sarracenia/issues/1315
+delete_source off
+delete_destination on
 skip 3

--- a/deploy/default/sarracenia/citypageweather.conf
+++ b/deploy/default/sarracenia/citypageweather.conf
@@ -9,4 +9,8 @@ directory ${MSC_PYGEOAPI_CACHEDIR}
 callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}
 mirror True
 discard True
+# workaround for discard directive bug in sr3
+# see https://github.com/MetPX/sarracenia/issues/1315
+delete_source off
+delete_destination on
 strip 3

--- a/deploy/default/sarracenia/coastal-flood-risk-index.conf
+++ b/deploy/default/sarracenia/coastal-flood-risk-index.conf
@@ -10,5 +10,9 @@ directory ${MSC_PYGEOAPI_CACHEDIR}
 callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}
 mirror True
 discard True
+# workaround for discard directive bug in sr3
+# see https://github.com/MetPX/sarracenia/issues/1315
+delete_source off
+delete_destination on
 logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}
 report False

--- a/deploy/default/sarracenia/hurricanes.conf
+++ b/deploy/default/sarracenia/hurricanes.conf
@@ -9,4 +9,8 @@ directory ${MSC_PYGEOAPI_CACHEDIR}
 callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}
 mirror True
 discard True
+# workaround for discard directive bug in sr3
+# see https://github.com/MetPX/sarracenia/issues/1315
+delete_source off
+delete_destination on
 slip 3

--- a/deploy/default/sarracenia/hydrometric-realtime.conf
+++ b/deploy/default/sarracenia/hydrometric-realtime.conf
@@ -9,6 +9,10 @@ directory ${MSC_PYGEOAPI_CACHEDIR}
 callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}
 logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}
 discard True
+# workaround for discard directive bug in sr3
+# see https://github.com/MetPX/sarracenia/issues/1315
+delete_source off
+delete_destination on
 report False
 skip 3
 

--- a/deploy/default/sarracenia/metnotes.conf
+++ b/deploy/default/sarracenia/metnotes.conf
@@ -9,5 +9,9 @@ directory ${MSC_PYGEOAPI_CACHEDIR}
 callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}
 mirror True
 discard True
+# workaround for discard directive bug in sr3
+# see https://github.com/MetPX/sarracenia/issues/1315
+delete_source off
+delete_destination on
 report False
 logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}

--- a/deploy/default/sarracenia/swob-realtime.conf
+++ b/deploy/default/sarracenia/swob-realtime.conf
@@ -9,6 +9,10 @@ directory ${MSC_PYGEOAPI_CACHEDIR}
 callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}
 mirror True
 discard True
+# workaround for discard directive bug in sr3
+# see https://github.com/MetPX/sarracenia/issues/1315
+delete_source off
+delete_destination on
 logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}
 report False
 skip 3

--- a/deploy/default/sarracenia/thunderstorm-outlook.conf
+++ b/deploy/default/sarracenia/thunderstorm-outlook.conf
@@ -10,5 +10,9 @@ directory ${MSC_PYGEOAPI_CACHEDIR}
 callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}
 mirror True
 discard True
+# workaround for discard directive bug in sr3
+# see https://github.com/MetPX/sarracenia/issues/1315
+delete_source off
+delete_destination on
 logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}
 report False

--- a/deploy/default/sarracenia/umos-realtime.conf
+++ b/deploy/default/sarracenia/umos-realtime.conf
@@ -10,5 +10,9 @@ directory ${MSC_PYGEOAPI_CACHEDIR}
 callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}
 mirror True
 discard True
+# workaround for discard directive bug in sr3
+# see https://github.com/MetPX/sarracenia/issues/1315
+delete_source off
+delete_destination on
 logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}
 report False


### PR DESCRIPTION
This PR ensures the `delete_source` and `delete_destionation` directives are present whenver the `discard True` directive is specified in msc-pygeoapi sr3 subscribers. Without these changes, files received via subscribers are never removed from disk after being handled by the callback function.

See https://github.com/MetPX/sarracenia/issues/1315.

This will need to be backported to the latest `0.13` release.