### PR TITLE
fix data path for cansips products collections

### DIFF
--- a/deploy/default/msc-pygeoapi-config.yml
+++ b/deploy/default/msc-pygeoapi-config.yml
@@ -4273,7 +4273,7 @@ resources:
         providers:
             - type: coverage
               name: msc_pygeoapi.provider.cansips_products_rasterio.CanSIPSProductsProvider
-              data: /datasan/geomet/local/cansips-archives/100km/forecast/2023/10/202310_MSC_CanSIPS_AirTemp-ProbAboveNormal_AGL-2m_LatLon1.0_P00M-P02M.grib2
+              data: /data/geomet/local/cansips-archives/100km/forecast/2023/10/202310_MSC_CanSIPS_AirTemp-ProbAboveNormal_AGL-2m_LatLon1.0_P00M-P02M.grib2
               options:
                   DATA_ENCODING: COMPLEX_PACKING
               format:
@@ -4310,7 +4310,7 @@ resources:
         providers:
             - type: coverage
               name: msc_pygeoapi.provider.cansips_products_rasterio.CanSIPSProductsProvider
-              data: /datasan/geomet/local/cansips-archives/100km/forecast/2025/03/202503_MSC_CanSIPS_AirTemp-ProbAboveNormal_AGL-2m_LatLon1.0_P00M.grib2
+              data: /data/geomet/local/cansips-archives/100km/forecast/2025/03/202503_MSC_CanSIPS_AirTemp-ProbAboveNormal_AGL-2m_LatLon1.0_P00M.grib2
               options:
                   DATA_ENCODING: COMPLEX_PACKING
               format:

--- a/docker/default.env
+++ b/docker/default.env
@@ -14,6 +14,7 @@ MSC_PYGEOAPI_LOCALE=${BASEDIR}/msc-pygeoapi/locale
 
 GEOMET_HPFX_BASEPATH=/data/geomet/feeds/hpfx
 GEOMET_SCIENCE_BASEPATH=/data/geomet/feeds/cmoi-science
+GEOMET_LOCAL_BASEPATH=/data/geomet/local
 
 XDG_CACHE_HOME=/tmp/msc-pygeoapi-sarra-logs
 


### PR DESCRIPTION
Fix collection data path for  CanSIPS products coverage collections and ensure `GEOMET_LOCAL_BASEPATH` is set in default Docker environment.