### PR TITLE
mv hurricane feed to dd-alpha

### DIFF
--- a/deploy/default/sarracenia/hurricanes.conf
+++ b/deploy/default/sarracenia/hurricanes.conf
@@ -1,9 +1,11 @@
-broker amqps://MSC-GEOMET@hpfx.collab.science.gc.ca
+#broker amqps://MSC-GEOMET@hpfx.collab.science.gc.ca
+broker amqps://MSC-GEOMET@dd.alpha.weather.gc.ca
 exchange xpublic
 queueName q_${BROKER_USER}.${PROGRAM}.${CONFIG}.${HOSTNAME}
 instances 2
 
-subtopic *.WXO-DD.hurricanes.#
+#subtopic *.WXO-DD.hurricanes.#
+subtopic hurricanes.#
 
 directory ${MSC_PYGEOAPI_CACHEDIR}
 callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}
@@ -13,4 +15,4 @@ discard True
 # see https://github.com/MetPX/sarracenia/issues/1315
 delete_source off
 delete_destination on
-slip 3
+#strip 3


### PR DESCRIPTION
moving hurricanes feed to dd-alpha, it will be available as experimental for the upcoming hurricane season in GeoMet-OGC-API.