### PR TITLE
fix cluster wrongly shown and zoom out when there are 0 results issue-967

### DIFF
--- a/theme/static/js/composables/useMap.js
+++ b/theme/static/js/composables/useMap.js
@@ -94,7 +94,7 @@ export default function useMap(mapElemId, geoJsonData, itemsPath, tileLayerUrl, 
     // feature collection
     if (Object.prototype.hasOwnProperty.call(geoJsonData.value, 'features')) {
       if (geoJsonData.value.features.length === 0 || geoJsonData.value.features[0].geometry === null) {
-        map.setView([0, 0], 1)
+        markers.clearLayers();
         return false
       }
     } else if (geoJsonData.value.type === 'Feature') { // single feature


### PR DESCRIPTION
This PR fixes a bug where requests on the GeoMet-OGC-API that have 0 results may display the results from a previous request on the map.

Additionally, this PR stops a zoom out to the entire world when there are 0 results.