### PR TITLE
make table vertically resizable to show more entries in items page issue-972

### DIFF
--- a/theme/static/css/default.css
+++ b/theme/static/css/default.css
@@ -49,6 +49,8 @@
 #items-table-container {
   height: 400px;
   overflow: scroll;
+  resize:vertical;
+  min-height: 400px;
 }
 
 footer.sticky {


### PR DESCRIPTION
This PR adds a CSS element to the bottom right of item tables that allows a user to resize the table vertically. It is meant to allow a user to display the entirety of an entry's property that contains a long value.