### PR TITLE
fix KeyError when index name is alias or wildcard

### DIFF
--- a/msc_pygeoapi/provider/elasticsearch.py
+++ b/msc_pygeoapi/provider/elasticsearch.py
@@ -58,7 +58,17 @@ class MSCElasticsearchProvider(ElasticsearchProvider):
         :returns: `str` of time_field format
         """
         mapping = self.es.indices.get_mapping(index=self.index_name)
-        p = mapping[self.index_name]['mappings']['properties']['properties']
+        try:
+            p = mapping[self.index_name]['mappings']['properties'][
+                'properties'
+            ]
+        except KeyError:
+            LOGGER.debug(
+                'Could not find index name in mapping. '
+                'Setting from first matching index.'
+            )
+            index_name_ = list(mapping.keys())[0]
+            p = mapping[index_name_]['mappings']['properties']['properties']
 
         format_ = p['properties'][self.time_field].get('format')
 


### PR DESCRIPTION
This PR fixes an issue where when using aliased index names or wildcarded index names the mapping could not be retrieved since ES returns the mapping with the non-aliased name (i,e `climate_public_climate_summary.2024-12-18` instead of `climate_public_climate_summary`) or multiple mappings for each index matching the wildcard. 

This would result in a `KeyError` and queries failing when attempting to retrieve the `time_field` format from ES for wildcarded or aliased index names.

CC @RousseauLambertLP 

