### PR TITLE
update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click
 dask
 elasticsearch>=8,<9
-fiona<1.10
+fiona
 fsspec
 gdal<=3.8.4
 lxml
@@ -9,7 +9,7 @@ netcdf4
 pandas
 parse
 pygeometa
-pyproj<3.5
+pyproj
 python-slugify
 pyyaml
 rasterio<1.4


### PR DESCRIPTION
This PR updates requirements to align with recent updates to UbuntuGIS stable.

* `fiona` is there for STAC support and is unpinned in the [pygeoapi requirements-provider.txt](https://github.com/geopython/pygeoapi/blob/master/requirements-provider.txt) document.
* According to the [pyproj documentation](https://pyproj4.github.io/pyproj/stable/installation.html#installing-from-source), pyproj 3.7+ is now compatible with PROJ 9.2+. We currently have it pinned to <3.5 but this is no longer needed since we now have PROJ 9.3.3 installed on our systems from UbuntuGIS stable.

This will help ensure we don't get a `pkg_resources.ContextualVersionConflict` error when installing down the line on our Jammy infra.