### PR TITLE
Add #coverages-map to default CSS settings

### DIFF
--- a/theme/static/css/default.css
+++ b/theme/static/css/default.css
@@ -42,7 +42,7 @@
   top: 0; /* sticky table header */
 }
 
-#items-map, #collection-map {
+#items-map, #collection-map, #coverages-map {
   width: 100%;
   height: 400px;
 }


### PR DESCRIPTION
This PR fixes the CSS leaflet map display in EDR query.html template