### PR TITLE
pin xarray to be compatible with python 3.10 to avoid Github actions test error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ pyyaml
 rasterio<1.4
 requests
 sqlalchemy
-xarray
+xarray<2025.0.0


### PR DESCRIPTION
This PR fixes the error shown in Github actions' test: https://github.com/ECCC-MSC/msc-pygeoapi/actions/runs/16228115079/job/45824713017

```
/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/xarray-2025.7.1-py3.10.egg/xarray/core/types.py:6: in <module>
    from typing import (
E   ImportError: cannot import name 'Self' from 'typing' (/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/typing.py)
```

This issue is because of a version of xarray that is meant for Python 3.11 is being installed where `import name 'Self' from 'typing'` is allowed, but that is not supported in Python 3.10.

Pinning `xarray<2025.0.0` will resolve this issue as it will restrict installing a version compatible with Python 3.10.