### PR TITLE
{BACKPORT] update citypageweather realtime subscriber

### DIFF
--- a/debian/conffiles
+++ b/debian/conffiles
@@ -1,6 +1,6 @@
 /opt/msc-pygeoapi/etc/sarracenia/bulletins-realtime.conf
 /opt/msc-pygeoapi/etc/sarracenia/cap-alerts.conf
-/opt/msc-pygeoapi/etc/sarracenia/citypageweather.conf
+/opt/msc-pygeoapi/etc/sarracenia/citypageweather-realtime.conf
 /opt/msc-pygeoapi/etc/sarracenia/hurricanes.conf
 /opt/msc-pygeoapi/etc/sarracenia/hydrometric-realtime.conf
 /opt/msc-pygeoapi/etc/sarracenia/marineweather-realtime.conf

--- a/deploy/default/sarracenia/citypageweather-realtime.conf
+++ b/deploy/default/sarracenia/citypageweather-realtime.conf
@@ -6,7 +6,9 @@ instances 2
 subtopic *.WXO-DD.citypage_weather.xml.*.#
 
 directory ${MSC_PYGEOAPI_CACHEDIR}/citypage_weather
-callback ${MSC_PYGEOAPI_METPX_FLOW_CALLBACK}
+callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}
 mirror True
 discard False
 strip 3
+logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}
+report False


### PR DESCRIPTION
This PR updates the CityPage Weather realtime sr3 subscriber and updates the callback directive and ensures logging and reporting are properly set.

This will need to be backported to the `0.15` release.