### PR TITLE
add sarracenia configuration for aqhi internal data feed

### DIFF
--- a/deploy/default/sarracenia/aqhi-internal-realtime.conf
+++ b/deploy/default/sarracenia/aqhi-internal-realtime.conf
@@ -1,0 +1,17 @@
+broker amqps://CMC-DEV@ddsr.cmc.ec.gc.ca/
+exchange xpublic
+queueName q_${BROKER_USER}.${PROGRAM}.${CONFIG}.${HOSTNAME}
+instances 2
+
+subtopic *.MSC-SCI-CMC-OPS.geomet_only.air_quality.aqhi.#
+
+mirror True
+discard True
+# workaround for discard directive bug in sr3
+# see https://github.com/MetPX/sarracenia/issues/1315
+delete_source off
+delete_destination on
+report False
+directory ${MSC_PYGEOAPI_CACHEDIR}
+logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}
+callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}


### PR DESCRIPTION
This PR adds a sarracenia configuration to retrieve internal AQHI data as requested by CMOA.