### PR TITLE
Fix bug where format string was not created properly for time header in CSV downloads

### DIFF
--- a/msc_pygeoapi/process/cccs/raster_drill.py
+++ b/msc_pygeoapi/process/cccs/raster_drill.py
@@ -323,7 +323,7 @@ def serialize(values_dict, cfg, output_format, x, y):
             pctl_en = pctl_fr = ''
 
         if output_format == 'CSV':
-            time_ = 'time_{time_begin}/{time_end}/{time_step}'
+            time_ = f'time_{time_begin}/{time_end}/{time_step}'
             row = [time_,
                    'values',
                    'longitude',


### PR DESCRIPTION
The f was missing in front of the f-string so the date passed would always be a string of the names of the time variables.

@tomkralidis please have a look when you have time.