### PR TITLE
update citypageweater realtime subscriber subtopic paths

### DIFF
--- a/deploy/default/sarracenia/citypageweather-realtime.conf
+++ b/deploy/default/sarracenia/citypageweather-realtime.conf
@@ -3,7 +3,19 @@ exchange xpublic
 queueName q_${BROKER_USER}.${PROGRAM}.${CONFIG}.${HOSTNAME}
 instances 2
 
-subtopic *.WXO-DD.citypage_weather.xml.*.#
+subtopic *.WXO-DD.citypage_weather.AB.#
+subtopic *.WXO-DD.citypage_weather.BC.#
+subtopic *.WXO-DD.citypage_weather.MB.#
+subtopic *.WXO-DD.citypage_weather.NB.#
+subtopic *.WXO-DD.citypage_weather.NL.#
+subtopic *.WXO-DD.citypage_weather.NS.#
+subtopic *.WXO-DD.citypage_weather.NT.#
+subtopic *.WXO-DD.citypage_weather.NU.#
+subtopic *.WXO-DD.citypage_weather.ON.#
+subtopic *.WXO-DD.citypage_weather.PE.#
+subtopic *.WXO-DD.citypage_weather.QC.#
+subtopic *.WXO-DD.citypage_weather.SK.#
+subtopic *.WXO-DD.citypage_weather.YT.#
 
 directory ${MSC_PYGEOAPI_CACHEDIR}/citypage_weather
 callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}


### PR DESCRIPTION
This PR updates the CitypageWeather subcriber's subtopic paths due to changes upstream.

Must be backported to `0.15`.