### PR TITLE
Specify pyproj import version to avoid import issues seen in version 3.7+ issue-1246

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ netcdf4
 pandas
 parse
 pygeometa
-pyproj
+pyproj<=3.6.1
 python-slugify
 pyyaml
 rasterio<1.4


### PR DESCRIPTION
With the release of pyproj 3.7.2, an error occurs when the auto tester attempts to install packages for testing a new PR's changes. 
In order to avoid this, the pyproj version is being limited to at most 3.6.1 because it is a version that is known to work without issues and aligns with Ubuntu packaging.

CC @kngai 