### PR TITLE
Fix swob stations config

### DIFF
--- a/deploy/default/msc-pygeoapi-config.yml
+++ b/deploy/default/msc-pygeoapi-config.yml
@@ -1197,7 +1197,7 @@ resources:
               id_field: id
               time_field: date_tm-value
 
-    swob-station:
+    swob-stations:
         type: collection
         title:
             en: SWOB - Stations
@@ -1235,7 +1235,7 @@ resources:
               data: ${MSC_PYGEOAPI_ES_URL}/swob-surface-stations
               id_field: id
 
-    swob-partner-station:
+    swob-partner-stations:
         type: collection
         title:
             en: SWOB - Stations from Partners
@@ -1273,7 +1273,7 @@ resources:
               data: ${MSC_PYGEOAPI_ES_URL}/swob-partner-stations
               id_field: id
 
-    swob-marine-station:
+    swob-marine-stations:
         type: collection
         title:
             en: SWOB - Stations for Marine


### PR DESCRIPTION
As requested, SWOB station datasets ids require the plural form "stations" instead of "station.

@tomkralidis I am not exactly sure if this is the only file that requires changes. Let me know if there are any other.

cc: @alexandreleroux 