### PR TITLE
ensure msc_pygeoapi logger is set and pass logger instance to sr3 FlowCB object

### DIFF
--- a/deploy/default/sarracenia/aqhi-internal-realtime.conf
+++ b/deploy/default/sarracenia/aqhi-internal-realtime.conf
@@ -13,5 +13,4 @@ delete_source off
 delete_destination on
 report False
 directory ${MSC_PYGEOAPI_CACHEDIR}
-logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}
 callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}

--- a/deploy/default/sarracenia/aqhi-realtime.conf
+++ b/deploy/default/sarracenia/aqhi-realtime.conf
@@ -13,5 +13,4 @@ delete_source off
 delete_destination on
 report False
 directory ${MSC_PYGEOAPI_CACHEDIR}
-logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}
 callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}

--- a/deploy/default/sarracenia/bulletins-realtime.conf
+++ b/deploy/default/sarracenia/bulletins-realtime.conf
@@ -9,5 +9,4 @@ mirror True
 download off
 directory /dev/null
 callback ${MSC_PYGEOAPI_METPX_EVENT_MESSAGE_PY}
-logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}
 report False

--- a/deploy/default/sarracenia/citypageweather-realtime.conf
+++ b/deploy/default/sarracenia/citypageweather-realtime.conf
@@ -22,5 +22,4 @@ callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}
 mirror True
 discard False
 strip 3
-logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}
 report False

--- a/deploy/default/sarracenia/coastal-flood-risk-index.conf
+++ b/deploy/default/sarracenia/coastal-flood-risk-index.conf
@@ -14,5 +14,4 @@ discard True
 # see https://github.com/MetPX/sarracenia/issues/1315
 delete_source off
 delete_destination on
-logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}
 report False

--- a/deploy/default/sarracenia/hydrometric-realtime.conf
+++ b/deploy/default/sarracenia/hydrometric-realtime.conf
@@ -7,7 +7,6 @@ subtopic *.WXO-DD.hydrometric.#
 
 directory ${MSC_PYGEOAPI_CACHEDIR}
 callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}
-logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}
 discard True
 # workaround for discard directive bug in sr3
 # see https://github.com/MetPX/sarracenia/issues/1315

--- a/deploy/default/sarracenia/marineweather-realtime.conf
+++ b/deploy/default/sarracenia/marineweather-realtime.conf
@@ -7,7 +7,6 @@ subtopic *.WXO-DD.marine_weather.#
 
 directory ${MSC_PYGEOAPI_CACHEDIR}
 callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}
-logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}
 mirror True
 strip 3
 

--- a/deploy/default/sarracenia/metnotes.conf
+++ b/deploy/default/sarracenia/metnotes.conf
@@ -14,4 +14,3 @@ discard True
 delete_source off
 delete_destination on
 report False
-logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}

--- a/deploy/default/sarracenia/swob-realtime.conf
+++ b/deploy/default/sarracenia/swob-realtime.conf
@@ -13,6 +13,5 @@ discard True
 # see https://github.com/MetPX/sarracenia/issues/1315
 delete_source off
 delete_destination on
-logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}
 report False
 skip 3

--- a/deploy/default/sarracenia/thunderstorm-outlook.conf
+++ b/deploy/default/sarracenia/thunderstorm-outlook.conf
@@ -14,5 +14,4 @@ discard True
 # see https://github.com/MetPX/sarracenia/issues/1315
 delete_source off
 delete_destination on
-logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}
 report False

--- a/deploy/default/sarracenia/umos-realtime.conf
+++ b/deploy/default/sarracenia/umos-realtime.conf
@@ -14,5 +14,4 @@ discard True
 # see https://github.com/MetPX/sarracenia/issues/1315
 delete_source off
 delete_destination on
-logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}
 report False

--- a/deploy/default/sarracenia/weatherstories.conf
+++ b/deploy/default/sarracenia/weatherstories.conf
@@ -9,5 +9,4 @@ subtopic #
 strip 2
 directory ${MSC_PYGEOAPI_CACHEDIR}
 callback msc_pygeoapi.event.EventAfterWork
-logLevel ${MSC_PYGEOAPI_LOGGING_LOGLEVEL}
 report False

--- a/msc_pygeoapi/connector/elasticsearch_.py
+++ b/msc_pygeoapi/connector/elasticsearch_.py
@@ -48,6 +48,9 @@ from msc_pygeoapi.env import (
 
 LOGGER = logging.getLogger(__name__)
 elastic_logger.setLevel(getattr(logging, MSC_PYGEOAPI_LOGGING_LOGLEVEL))
+logging.getLogger('elastic_transport').setLevel(
+    getattr(logging, MSC_PYGEOAPI_LOGGING_LOGLEVEL)
+)
 
 
 class ElasticsearchConnector(BaseConnector):
@@ -118,7 +121,7 @@ class ElasticsearchConnector(BaseConnector):
             self.Elasticsearch.indices.exists(index=index_name)
             and not overwrite
         ):
-            LOGGER.info('{} index already exists.')
+            LOGGER.info(f'{index_name} index already exists.')
             return False
 
         elif self.Elasticsearch.indices.exists(index=index_name) and overwrite:

--- a/msc_pygeoapi/event/__init__.py
+++ b/msc_pygeoapi/event/__init__.py
@@ -41,6 +41,15 @@ LOGGER = logging.getLogger(__name__)
 
 class EventBase(FlowCB):
 
+    def __init__(self, options) -> None:
+        """
+        initializer
+
+        :param options: configuration options
+        """
+
+        super().__init__(options, LOGGER)
+
     def process_message(self, worklist, worklist_type) -> bool:
         """
         Process sarracenia message
@@ -74,7 +83,7 @@ class EventBase(FlowCB):
 
 class EventAfterWork(EventBase):
 
-    def after_work(self, worklist) -> None:
+    def after_work(self, worklist) -> bool:
         """
         sarracenia after_work dispatcher
 
@@ -88,7 +97,7 @@ class EventAfterWork(EventBase):
 
 class EventAfterAccept(EventBase):
 
-    def after_accept(self, worklist) -> None:
+    def after_accept(self, worklist) -> bool:
         """
         sarracenia after_accept dispatcher
 

--- a/msc_pygeoapi/log.py
+++ b/msc_pygeoapi/log.py
@@ -50,7 +50,7 @@ def setup_logger(loglevel, logfile=None):
         'WARNING': logging.WARNING,
         'INFO': logging.INFO,
         'DEBUG': logging.DEBUG,
-        'NOTSET': logging.NOTSET,
+        'NOTSET': logging.NOTSET
     }
 
     loglevel = loglevels[loglevel]
@@ -61,12 +61,21 @@ def setup_logger(loglevel, logfile=None):
                 level=loglevel,
                 datefmt=date_format,
                 format=log_format,
-                stream=sys.stdout,
+                stream=sys.stdout
             )
         else:
             logging.basicConfig(
                 level=loglevel,
                 datefmt=date_format,
                 format=log_format,
-                filename=logfile,
+                filename=logfile
             )
+    else:
+        logging.basicConfig(
+            level=loglevel,
+            datefmt=date_format,
+            format=log_format
+        )
+
+    # set msc-pygeoapi logger level to allow propagation to child loggers
+    logging.getLogger('msc_pygeoapi').setLevel(loglevel)


### PR DESCRIPTION
This PR makes several improvements to logging following requests by SSC-DI to improve feed monitoring. The following improvements have been made:

1.  `./msc_pygeoapi/log.py`: Ensure the `msc_pygeoapi`  logger's level is properly set to ensure the successful propagation of the `MSC_PYGEOAPI_LOGGING_LOGLEVEL` to all child logger instances. Prior to this change, modules were inheriting the log level of the root logger.

2. Remove `logLevel` directives from sr3 susbcriber configurations to allow for sr3 logging level to be managed by `~/.config/sr3/default.conf``.

3.  `./msc_pygeoapi/connector/elasticsearch_.py`: Set the `elastic_transport` logging level in the `msc_pygeoapi.connector.ElasticsearchConnector` instance to that of `MSC_PYGEOAPI_LOGGING_LEVEL` to ensure its log level is dictated by msc-pygeoapi's own log level. Otherwise, logging was often more verbose than that of msc-pygeoapi loggers.

4.  Ensure the `msc_pygeoapi.event` logger is passed to the sarracenia FlowCB instance. This allow's sarracenia to set its own log level via the `logLevel` directive in a sr3 subscriber configuration.

5. Small function annotation fix for `msc_pygeoapi.event.EventAfterWork` and `msc_pygeoapi.event.EventAfterAccept` classes to indicate the return value is a `bool` rather than `None`.

6. Fixed an f-string error in the `msc_pygeoapi.connector.ElasticsearchConnector.create()` method.

I have tested the above with a sarracenia sr3 subscriber configured to use the msc_pygeoapi callback. With msc_pygeoapi logging set to `ERROR` and the `logLevel` directive in the subscriber set to `info`, all info level messages and up from sarracenia are included in the sarracenia logs while only error level and above messages are shown for msc-pygeoapi.
