### PR TITLE
BUGFIX: Fix empty index (query errors) for some collections

### DIFF
--- a/deploy/default/msc-pygeoapi-config.yml
+++ b/deploy/default/msc-pygeoapi-config.yml
@@ -1690,7 +1690,7 @@ resources:
         providers:
             - type: feature
               name: Elasticsearch
-              data: ${MSC_PYGEOAPI_ES_URL}/hurricanes-cyclone.*
+              data: ${MSC_PYGEOAPI_ES_URL}/hurricanes-cyclone*
               id_field: id
               time_field: validity_datetime
 
@@ -1729,7 +1729,7 @@ resources:
         providers:
             - type: feature
               name: Elasticsearch
-              data: ${MSC_PYGEOAPI_ES_URL}/hurricanes-track.*
+              data: ${MSC_PYGEOAPI_ES_URL}/hurricanes-track*
               id_field: id
               time_field: validity_datetime
 
@@ -1768,7 +1768,7 @@ resources:
         providers:
             - type: feature
               name: Elasticsearch
-              data: ${MSC_PYGEOAPI_ES_URL}/hurricanes-error_cone.*
+              data: ${MSC_PYGEOAPI_ES_URL}/hurricanes-error_cone*
               id_field: id
               time_field: validity_datetime
 
@@ -1807,7 +1807,7 @@ resources:
         providers:
             - type: feature
               name: Elasticsearch
-              data: ${MSC_PYGEOAPI_ES_URL}/hurricanes-wind_radii.*
+              data: ${MSC_PYGEOAPI_ES_URL}/hurricanes-wind_radii*
               id_field: id
               time_field: validity_datetime
 
@@ -2079,7 +2079,7 @@ resources:
         providers:
             - type: feature
               name: Elasticsearch
-              data: ${MSC_PYGEOAPI_ES_URL}/metnotes.*
+              data: ${MSC_PYGEOAPI_ES_URL}/metnotes*
               id_field: id
               time_field: publication_datetime
               properties:


### PR DESCRIPTION
BUGFIX (see issue 1226), this needs to be backported

Fix empty index for some collections that were returning "query errors" for empty indexes (hurricane, metnotes). We now create an empty index for metntoes and the hurriacne which will be used if no features are available at the moment.

cc @Dukestep 