### PR TITLE
Added 'pip3 install --upgrade packaging' to fix packaging error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get install -y python3 python3-setuptools python3-pip git curl unzip pyt
 # install pygeoapi
 RUN git clone $PYGEOAPI_GITREPO -b 0.20.0 && \
     cd pygeoapi && \
+    pip3 install --upgrade packaging && \
     pip3 install -r requirements.txt && \
     pip3 install flask_cors gunicorn gevent greenlet && \
     pip3 install . && \


### PR DESCRIPTION
This PR fixes the Docker build error we encountered:

```
#11 20.92         File "/usr/local/lib/python3.10/dist-packages/setuptools/_core_metadata.py", line 293, in _distribution_fullname
#11 20.92           canonicalize_version(version, strip_trailing_zero=False),
#11 20.92       TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'
#11 20.92       [end of output]
```