### PR TITLE
update SQL for climate daily generation

### DIFF
--- a/msc_pygeoapi/loader/climate_archive.py
+++ b/msc_pygeoapi/loader/climate_archive.py
@@ -841,7 +841,7 @@ class ClimateArchiveLoader(BaseLoader):
             if not date:
                 try:
                     self.cur.execute(
-                        f'select * from CCCS_PORTAL.PUBLIC_DAILY_DATA '
+                        f'select * from CCCS_PORTAL.PUBLIC_DAILY_DATA_BULK '
                         f'where STN_ID={station}'
                     )
                 except Exception as err:
@@ -853,7 +853,7 @@ class ClimateArchiveLoader(BaseLoader):
                 try:
                     self.cur.execute(
                         (
-                            f"select * from CCCS_PORTAL.PUBLIC_DAILY_DATA "
+                            f"select * from CCCS_PORTAL.PUBLIC_DAILY_DATA_BULK "  #noqa
                             f"where STN_ID={station} and "
                             f"LOCAL_DATE > TO_TIMESTAMP('{date} 00:00:00', "
                             f"'YYYY-MM-DD HH24:MI:SS')"


### PR DESCRIPTION
This PR updates the climate archive loader to ensure it uses the latest SQL view for the loading of climate daily records as per changes discussed in msc-geomet#1119.