### PR TITLE
Comment out ports setting in docker-compose

### DIFF
--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -29,5 +29,6 @@
 
 services:
   msc-pygeoapi:
-    ports:
-      - 5089:5089
+    # ports not needed with network_mode: host
+    # ports:
+    #   - 5089:5089


### PR DESCRIPTION
This PR removes the docker ports setting since we have `network_mode: host` on. The ports assignment is handled in `entrypoint.sh`. Otherwise, `docker-compose up` will result in this warning message: `Published ports are discarded when using host network mode`