### PR TITLE
switch data source and status of coastal flooding risk index

### DIFF
--- a/deploy/default/msc-pygeoapi-config.yml
+++ b/deploy/default/msc-pygeoapi-config.yml
@@ -4553,8 +4553,8 @@ resources:
     coastal_flood_risk_index:
         type: collection
         title:
-            en: Coastal Flooding Risk Index [experimental]
-            fr: Indice de risque de submersion côtière [expérimental]
+            en: Coastal Flooding Risk Index
+            fr: Indice de risque de submersion côtière
         description:
             en: The Coastal Flooding Risk Index is a geo- and time-referenced polygon product issued by the Meteorological Service of Canada (MSC) to articulate the coastal flooding risk, impact and probability. Products are issued daily by Storm Prediction Centres and are intended to provide early notification, out to 5 days, of coastal flooding due to astronomical tide, storm surge and wave impacts.
             fr: L'indice de risque de submersion côtière est un produit polygonal géoréférencé et temporel émis par le Service météorologique du Canada (SMC) afin d'articuler le risque, l'impact et la probabilité de submersion côtière. Les produits sont générés quotidiennement par les centres de prévision des intempéries et sont destinés à fournir une notification précoce, jusqu'à 5 jours, des submersions côtières dues aux marées astronomiques, aux ondes de tempête et aux impacts des vagues.

--- a/deploy/default/sarracenia/coastal-flood-risk-index.conf
+++ b/deploy/default/sarracenia/coastal-flood-risk-index.conf
@@ -1,10 +1,10 @@
 # TODO: Update for HPFX once the data is on HPFX
-broker ${MSC_PYGEOAPI_DD_ALPHA_AMQP_URL}
+broker ${MSC_PYGEOAPI_HPFX_AMQP_URL}
 exchange xpublic
 queueName q_${BROKER_USER}.${PROGRAM}.${CONFIG}.${HOSTNAME}
 instances 2
 
-subtopic coastal-flooding.risk-index.#
+subtopic *.WXO-DD.coastal-flooding.risk-index.#
 
 directory ${MSC_PYGEOAPI_CACHEDIR}
 callback ${MSC_PYGEOAPI_METPX_EVENT_FILE_PY}


### PR DESCRIPTION
This PR addresses msc-geomet#1354 and ensures the experimental status of the CFRI collection is removed now that the data is available on HPFX/DD. It also updates the sr3 subscriber to source the data from HPFX.

CC @RousseauLambertLP