### PR TITLE
update sarra feed to use only the new GDPS-SN feed for prognos

### DIFF
--- a/deploy/default/sarracenia/prognos-realtime.conf
+++ b/deploy/default/sarracenia/prognos-realtime.conf
@@ -3,10 +3,6 @@ exchange xpublic
 queueName q_${BROKER_USER}.${PROGRAM}.${CONFIG}.${HOSTNAME}
 instances 4
 
-# TODO: To be removed once GDPS-SN is ops (Spring 2026)
-subtopic *.WXO-DD.model_gem_global.stat-post-processing.#
-
-# new path fo prognos
 subtopic *.WXO-DD.model_gdps.stat-post-processing.#
 subtopic *.WXO-DD.model_rdps.stat-post-processing.#
 subtopic *.WXO-DD.model_hrdps.stat-post-processing.#


### PR DESCRIPTION
update sarra feed to use only the new GDPS-SN feed for prognos

See issue 1408