### PR TITLE
Stop null key from being used in ranges property of CanGRD coverage data issue-1439

### DIFF
--- a/msc_pygeoapi/provider/cangrd_rasterio.py
+++ b/msc_pygeoapi/provider/cangrd_rasterio.py
@@ -458,4 +458,15 @@ class CanGRDProvider(RasterioProvider):
 
         cj['parameters'] = parameter
 
+        ranges = {}
+        ranges[pm['id']] = {
+            'type': 'NdArray',
+            'dataType': 'float',
+            'axisNames': ['y', 'x'],
+            'shape': [metadata['height'], metadata['width']],
+            'values': data.flatten().tolist()
+        }
+
+        cj['ranges'] = ranges
+
         return cj


### PR DESCRIPTION
This PR ensures that the parameter from a CanGRD coverage data request is used as the key in its ranges property.

For details, see msc-geomet#1439.

CC @Dukestep 