### PR TITLE
fix CFRI collection ID

### DIFF
--- a/deploy/default/msc-pygeoapi-config.yml
+++ b/deploy/default/msc-pygeoapi-config.yml
@@ -4550,7 +4550,7 @@ resources:
               data: ${MSC_PYGEOAPI_ES_URL}/thunderstorm_outlook
               id_field: id
 
-    coastal_flood_risk_index:
+    coastal-flooding-risk-index:
         type: collection
         title:
             en: Coastal Flooding Risk Index


### PR DESCRIPTION
This MR fixes the collection ID for the Coastal Flooding Risk Index to be be more inline with existing collection names and align with changes done in #493.