### PR TITLE
[BUGFIX] return marine forecast location names as bilingual objects

### DIFF
--- a/msc_pygeoapi/loader/marine_weather_realtime.py
+++ b/msc_pygeoapi/loader/marine_weather_realtime.py
@@ -128,6 +128,23 @@ MAPPING = {
                         'locations': {
                             'type': 'nested',
                             'properties': {
+                                'name': {
+                                    'type': 'object',
+                                    'properties': {
+                                        'en': {
+                                            'type': 'text',
+                                            'fields': {
+                                                'keyword': {'type': 'keyword'}
+                                            }
+                                        },
+                                        'fr': {
+                                            'type': 'text',
+                                            'fields': {
+                                                'keyword': {'type': 'keyword'}
+                                            }
+                                        }
+                                    }
+                                },
                                 'weatherCondition': {
                                     'type': 'object',
                                     'properties': {
@@ -272,6 +289,23 @@ MAPPING = {
                         'locations': {
                             'type': 'nested',
                             'properties': {
+                                'name': {
+                                    'type': 'object',
+                                    'properties': {
+                                        'en': {
+                                            'type': 'text',
+                                            'fields': {
+                                                'keyword': {'type': 'keyword'}
+                                            }
+                                        },
+                                        'fr': {
+                                            'type': 'text',
+                                            'fields': {
+                                                'keyword': {'type': 'keyword'}
+                                            }
+                                        }
+                                    }
+                                },
                                 'weatherCondition': {
                                     'type': 'object',
                                     'properties': {
@@ -358,6 +392,23 @@ MAPPING = {
                         'locations': {
                             'type': 'nested',
                             'properties': {
+                                'name': {
+                                    'type': 'object',
+                                    'properties': {
+                                        'en': {
+                                            'type': 'text',
+                                            'fields': {
+                                                'keyword': {'type': 'keyword'}
+                                            }
+                                        },
+                                        'fr': {
+                                            'type': 'text',
+                                            'fields': {
+                                                'keyword': {'type': 'keyword'}
+                                            }
+                                        }
+                                    }
+                                },
                                 'weatherCondition': {
                                     'type': 'object',
                                     'properties': {
@@ -888,7 +939,7 @@ class MarineWeatherRealtimeLoader(BaseLoader):
                 self._set_nested_value(
                     location_dict,
                     ['name'],
-                    location_elem.attrib['name']
+                    {self.lang: location_elem.attrib['name']}
                 )
 
             # add weather condition elements
@@ -978,7 +1029,7 @@ class MarineWeatherRealtimeLoader(BaseLoader):
                 self._set_nested_value(
                     location_dict,
                     ['name'],
-                    location_elem.attrib['name']
+                    {self.lang: location_elem.attrib['name']}
                 )
 
             # add weatherCondition tags and forecastPeriod children
@@ -1080,7 +1131,7 @@ class MarineWeatherRealtimeLoader(BaseLoader):
                 self._set_nested_value(
                     location_dict,
                     ['name'],
-                    location_elem.attrib['name']
+                    {self.lang: location_elem.attrib['name']}
                 )
 
             # add weather condition elements


### PR DESCRIPTION
This PR fixes an inconsistency in the marineweather-realtime collection where the name field under `regularForecast.locations[]`, `extendedForecast.locations[]`, and `waveForecast.locations[]` was returned as a plain French-only string, while every other name in the response (e.g. area.value, warnings.locations[].name) is a bilingual { "en", "fr" } object.

Verified by running the loader against sample XML for the Strait of Georgia zone: regularForecast.locations[].name now returns { "en": "Strait of Georgia - south of Nanaimo", "fr": "Détroit de Georgie - au sud de Nanaimo" }.

See msc-geomet#1470 for further details.

Can be backported to `0.18` branch.