### PR TITLE
Improve overlapping polygons display in GeoMet-OGC-API issue-717

### DIFF
--- a/theme/static/css/default.css
+++ b/theme/static/css/default.css
@@ -176,3 +176,14 @@ ul.pd-lft-0 {
   float: right;
   width: 250px;
 }
+
+.popup-items-list {
+  list-style-type: none;
+  padding-left: 0;
+  overflow: auto;
+  max-height: 200px;
+}
+
+.popup-items-text {
+  padding-bottom: 5px;
+}

--- a/theme/static/js/composables/useMap.js
+++ b/theme/static/js/composables/useMap.js
@@ -1,9 +1,9 @@
-import 'leaflet-non-esm' 
+import 'leaflet-non-esm'
 import 'leaflet.markercluster'
 import { ref, computed, watch, onMounted, onBeforeMount } from 'vue'
 
 export default function useMap(mapElemId, geoJsonData, itemsPath, tileLayerUrl, tileLayerAttr, bboxPermalink, locale) {
-  let map, layerItems, markers
+  let map, layerItems, markers, pointIntersectedLayers, popupDisplayText, layerIdPopup, clickPopup
   const maxZoom = 15
   const bbox = ref('')
   // Leaflet LatLngBounds simple array format
@@ -13,7 +13,7 @@ export default function useMap(mapElemId, geoJsonData, itemsPath, tileLayerUrl, 
       return [[-85, -175], [85, 175]]
     } else {
       return [
-        [bboxSplit[1], bboxSplit[0]], 
+        [bboxSplit[1], bboxSplit[0]],
         [bboxSplit[3], bboxSplit[2]]
       ]
     }
@@ -26,6 +26,21 @@ export default function useMap(mapElemId, geoJsonData, itemsPath, tileLayerUrl, 
         }
         if (geoJsonData.value.features[0]['geometry']['type'] === 'Point') {
           return true
+        }
+      }
+    }
+    return false
+  })
+  const geoJsonIsPolygonGeometry = computed(() => {
+    if (Object.prototype.hasOwnProperty.call(geoJsonData.value, 'features')) {
+      if (geoJsonData.value.features.length > 0 ) {
+        const polygon_types = ['Polygon', 'MultiPolygon']
+        for (const feature_geometry of geoJsonData.value.features) {
+          if (![undefined, null].includes(feature_geometry['geometry'])) {
+            if (polygon_types.includes(feature_geometry['geometry']['type'])) {
+              return true
+            }
+          }
         }
       }
     }
@@ -54,6 +69,103 @@ export default function useMap(mapElemId, geoJsonData, itemsPath, tileLayerUrl, 
     bbox.value = bboxSplit.join(',')
   }
 
+  const updatePopup = function(evt) {
+    if (this.feature === undefined) {
+      return
+    }
+
+    let selectedLayer = this.feature.id
+    let intersectingPolygons = []
+
+    let latlng = map.mouseEventToLatLng(evt.originalEvent)
+    let [x, y] = [latlng.lng, latlng.lat]
+
+    // Gather IDs of layers that contain the coord
+    layerItems.eachLayer(function (layer) {
+      let inside = false
+      let coordinates = layer.feature.geometry.coordinates
+      if (layer.feature.id === selectedLayer) {
+        inside = true
+      } else if (layer.feature.geometry.type === 'MultiPolygon') {
+        for (const coordSet of coordinates) {
+          let currentPolygon = coordSet[0]
+          inside = checkIfInside(currentPolygon, x, y)
+          if (inside) {
+            break
+          }
+        }
+      } else {
+        let currentPolygon = coordinates[0]
+        inside = checkIfInside(currentPolygon, x, y)
+      }
+
+      if (inside) {
+        // Add the ID to the list of IDs to display in the popup
+        intersectingPolygons.push(layer.feature.id)
+      }
+    })
+    pointIntersectedLayers = intersectingPolygons
+
+    layerItems.eachLayer(function (layer) {
+      if (layer.feature.id === selectedLayer) {
+
+        // List element for the popup
+        popupDisplayText = document.createElement('ul')
+
+        // Each list item will be a link for an intersecting layer
+        pointIntersectedLayers.forEach(layerId => {
+          const url = itemsPath + '/' + layerId + `?lang=${locale}`
+          const anchorLink = document.createElement('a')
+          anchorLink.href = url
+          anchorLink.textContent = layerId
+          const li = document.createElement('li')
+          li.appendChild(anchorLink)
+          popupDisplayText.appendChild(li)
+        })
+
+        // Ensures each layer ID is spaced out
+        layerIdPopup = popupDisplayText.querySelectorAll('li:not(:last-child)')
+        layerIdPopup.forEach(li => {
+          li.classList.add('popup-items-text')
+        })
+
+        // Prevents the popup from displaying bullet points and
+        // adds a scroll bar when many layers intersect the point
+        popupDisplayText.classList.add('popup-items-list')
+
+        // Handles the highlighting of layers and resetting them back to normal
+        popupDisplayText.addEventListener('mouseover', hoverOver)
+        popupDisplayText.addEventListener('mouseout', hoverOff)
+
+        clickPopup = L.popup(L.latLng(y, x), {content: popupDisplayText})
+        clickPopup.openOn(map)
+
+        clickPopup.on('remove', function () {
+          popupDisplayText.removeEventListener('mouseover', hoverOver)
+          popupDisplayText.removeEventListener('mouseout', hoverOff)
+          popupDisplayText = null
+        })
+      }
+    })
+  }
+
+  const checkIfInside = function (currentPolygon, x, y) {
+    let result = false
+    let currPolyLen = currentPolygon.length
+
+    // Ray-Casting algorithm
+    for (let i=0, j=currPolyLen - 1; i < currPolyLen; j = i++) {
+      const [xi, yi] = currentPolygon[i]
+      const [xj, yj] = currentPolygon[j]
+      const intersect = ((yi > y) !== (yj > y)) &&
+        (x < (xj - xi) * (y - yi) / ((yj - yi) || 1e-16) + xi)
+      if (intersect) {
+        result = !result
+      }
+    }
+    return result
+  }
+
   // map initialize
   const setupMap = function() {
     map = L.map(mapElemId, {
@@ -75,7 +187,7 @@ export default function useMap(mapElemId, geoJsonData, itemsPath, tileLayerUrl, 
       chunkInterval: 500,
     })
     map.addLayer(markers)
-    
+
     if (geoJsonIsPointGeometry.value) {
       markers.clearLayers().addLayer(layerItems)
     } else {
@@ -90,13 +202,14 @@ export default function useMap(mapElemId, geoJsonData, itemsPath, tileLayerUrl, 
 
   // update map with new geoJson data
   watch(geoJsonData, (newData, oldData) => {
+    map.closePopup()
     if (map.hasLayer(layerItems) && geoJsonIsPointGeometry.value === false) {
       map.removeLayer(layerItems)
     }
-    
+
     // feature collection
     if (Object.prototype.hasOwnProperty.call(geoJsonData.value, 'features')) {
-      if (geoJsonData.value.features.length === 0 || geoJsonData.value.features[0].geometry === null) {
+      if (geoJsonData.value.features.length === 0) {
         markers.clearLayers();
         return false
       }
@@ -106,12 +219,25 @@ export default function useMap(mapElemId, geoJsonData, itemsPath, tileLayerUrl, 
         return false
       }
     }
-    
+
+    // To check if calling fitBounds is needed
+    let fitBbox = false
+
+    for (const feat of geoJsonData.value.features) {
+      if (feat.geometry !== null) {
+        fitBbox = true
+        break
+      }
+    }
+
     layerItems = new L.GeoJSON(geoJsonData.value, {
       onEachFeature: function (feature, layer) {
         let url = itemsPath + '/' + feature.id + `?lang=${locale}`
         let html = '<span><a href="' + url + '">' + feature.id + '</a></span>'
         layer.bindPopup(html)
+        if (geoJsonIsPolygonGeometry.value) {
+          layer.on('click', updatePopup)
+        }
       }
     })
 
@@ -122,17 +248,57 @@ export default function useMap(mapElemId, geoJsonData, itemsPath, tileLayerUrl, 
       map.addLayer(layerItems) // without MarkerClusterGroup
     }
 
-    if (bbox.value === '' || !bboxPermalink.value) { // no bbox
-      map.fitBounds(layerItems.getBounds(), {maxZoom: 5})
-    } else if (Object.keys(oldData).length === 0) { // first time load
-      // don't trigger moveend event after a fitBounds() to avoid overwriting original BBOX from permalink
-      map.off('moveend', updateBboxEvent) // temporarily remove moveend event
-      map.fitBounds(bboxLatLngBounds.value, {maxZoom: maxZoom})
-      setTimeout(() => { // add moveend event back after short delay
-        map.on('moveend', updateBboxEvent)
-      }, 2000)
+    if (fitBbox) {
+      if (bbox.value === '' || !bboxPermalink.value) { // no bbox
+        map.fitBounds(layerItems.getBounds(), {maxZoom: 5})
+      } else if (Object.keys(oldData).length === 0) { // first time load
+        // don't trigger moveend event after a fitBounds() to avoid overwriting original BBOX from permalink
+        map.off('moveend', updateBboxEvent) // temporarily remove moveend event
+        map.fitBounds(bboxLatLngBounds.value, {maxZoom: maxZoom})
+        setTimeout(() => { // add moveend event back after short delay
+          map.on('moveend', updateBboxEvent)
+        }, 2000)
+      }
     }
   })
+
+  const hoverOver = function(evt) {
+    evt.target.style.color = '#0535d2'
+
+    const highlightStyle = {
+      color: "#ff7800",
+      weight: 5,
+      fillOpacity: 0.5
+    }
+    const lessVisibleStyle = {
+      weight: 0,
+      fillOpacity: 0,
+      opacity: 0
+    }
+
+    layerItems.eachLayer(function (layer) {
+      if (layer.feature.id === evt.target.textContent) {
+        layer.setStyle(highlightStyle)
+        layer.bringToFront()
+      } else {
+        // make the other layers invisible
+        layer.setStyle(lessVisibleStyle)
+      }
+    })
+  }
+
+  const hoverOff = function(evt) {
+    evt.target.style.color = '#0078A8'
+    const defaultStyle = {
+      color: "#3388ff",
+      weight: 3,
+      fillOpacity: 0.2,
+      opacity: 1
+    }
+    layerItems.eachLayer(function (layer) {
+      layer.setStyle(defaultStyle)
+    })
+  }
 
   return {
     setupMap, bbox


### PR DESCRIPTION
This PR changes the popup for a clicked spot on the map of a polygon collection's items page. This popup lists all items whose polygons contain the clicked spot.

Hovering over one of the items' IDs in the popup will highlight that item's polygon.

CC @kngai 