### PR TITLE
[BUGFIX] added failsafe for empty feature_id for CAM alerts

### DIFF
--- a/msc_pygeoapi/loader/alerts_realtime.py
+++ b/msc_pygeoapi/loader/alerts_realtime.py
@@ -3,7 +3,7 @@
 # Author: Louis-Philippe Rousseau-Lambert
 #             <louis-philippe.rousseaulambert@ec.gc.ca>
 #
-# Copyright (c) 2025 Louis-Philippe Rousseau-Lambert
+# Copyright (c) 2026 Louis-Philippe Rousseau-Lambert
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -33,6 +33,7 @@ import json
 import logging
 import os
 from pathlib import Path
+import uuid
 
 import click
 from parse import parse
@@ -275,6 +276,11 @@ class AlertsRealtimeLoader(BaseLoader):
         self.index_date = None
         self.items = []
 
+    # To avoid having identical id for CAM alerts
+    def gen_uuid(self):
+
+        return str(uuid.uuid4())
+
     def parse_filename(self, filename):
         """
         Parses an alerts filename in order to get the date
@@ -339,7 +345,12 @@ class AlertsRealtimeLoader(BaseLoader):
         for feature in features:
             if feature['properties'].get('display_status') != 'contour':
                 prop_id = feature['properties']['id']
-                feat_id = feature['properties']['feature_id']
+
+                # if feature_id is null or empty
+                # we want to assign a uuid value instead
+                feat_id = feature['properties'].get('feature_id',
+                                                    self.short_uuid())
+
                 feature['id'] = f'{prop_id}_{feat_id}'
                 feature['properties']['id'] = feature['id']
 

--- a/msc_pygeoapi/loader/alerts_realtime_dev.py
+++ b/msc_pygeoapi/loader/alerts_realtime_dev.py
@@ -33,6 +33,7 @@ import json
 import logging
 import os
 from pathlib import Path
+import uuid
 
 import click
 from parse import parse
@@ -275,6 +276,11 @@ class AlertsRealtimeLoaderDev(BaseLoader):
         self.index_date = None
         self.items = []
 
+    # To avoid having identical id for CAM alerts
+    def gen_uuid(self):
+
+        return str(uuid.uuid4())
+
     def parse_filename(self, filename):
         """
         Parses an alerts filename in order to get the date
@@ -341,7 +347,12 @@ class AlertsRealtimeLoaderDev(BaseLoader):
         for feature in features:
             if feature['properties'].get('display_status') != 'contour':
                 prop_id = feature['properties']['id']
-                feat_id = feature['properties']['feature_id']
+
+                # if feature_id is null or empty
+                # we want to assign a uuid value instead
+                feat_id = feature['properties'].get('feature_id',
+                                                    self.gen_uuid())
+
                 feature['id'] = f'{prop_id}_{feat_id}'
                 feature['properties']['id'] = feature['id']
 


### PR DESCRIPTION
[BUGFIX] - Backport required

Added failsafe for empty feature_id for CAM alerts by generating a id using uuid if feature_id is emtpy

See MSC GeoMet issue 1517

cc @alexandreleroux 